### PR TITLE
Add motivational phrase library for audio coaching cues

### DIFF
--- a/src/glasses/audio/motivational.py
+++ b/src/glasses/audio/motivational.py
@@ -1,5 +1,9 @@
 """Motivational phrases for in-ear audio coaching cues."""
 
+import random
+
+from src.contracts.common import TriggerType
+
 SET_START_PHRASES = [
     "Let's go, own this set.",
     "Dial it in, you've got this.",
@@ -18,3 +22,18 @@ SET_COMPLETE_PHRASES = [
     "That's one in the bank.",
     "Clean finish.",
 ]
+
+_PHRASES_BY_TRIGGER = {
+    TriggerType.EXERCISE_START: SET_START_PHRASES,
+    TriggerType.REST_START: REST_PHRASES,
+    TriggerType.REST_END: SET_START_PHRASES,
+    TriggerType.SET_COMPLETE: SET_COMPLETE_PHRASES,
+}
+
+
+def pick_phrase(trigger: TriggerType) -> str | None:
+    """Return a random motivational phrase for the given trigger, or None."""
+    phrases = _PHRASES_BY_TRIGGER.get(trigger)
+    if not phrases:
+        return None
+    return random.choice(phrases)

--- a/src/glasses/audio/motivational.py
+++ b/src/glasses/audio/motivational.py
@@ -1,0 +1,20 @@
+"""Motivational phrases for in-ear audio coaching cues."""
+
+SET_START_PHRASES = [
+    "Let's go, own this set.",
+    "Dial it in, you've got this.",
+    "Stay tight, stay focused.",
+    "Strong reps only.",
+]
+
+REST_PHRASES = [
+    "Breathe deep, reset.",
+    "Shake it out, recover.",
+    "Good work. Rest up.",
+]
+
+SET_COMPLETE_PHRASES = [
+    "Set down. Nice work.",
+    "That's one in the bank.",
+    "Clean finish.",
+]


### PR DESCRIPTION
## Summary
- Seed `src/glasses/audio/` with a small motivational phrase library keyed by `TriggerType` (set start, rest, set complete).
- Add `pick_phrase(trigger)` helper so the audio layer can fetch a random in-ear motivational line without knowing the underlying lists.

Minimal, non-invasive first step toward the coaching/audio feedback feature — real TTS playback and integration with `CoachingCue` can layer on later.

## Test plan
- [x] Smoke test: `pick_phrase(TriggerType.EXERCISE_START)` returns a phrase; unmapped triggers return `None`.
- [ ] Wire into the glasses audio playback path once that exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)