### PR TITLE
Add manual logging fallback in src/sensing (#25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 venv/
+.venv/
 __pycache__/
+*.egg-info/
 .env

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,91 @@
+import sys
+from datetime import datetime, timedelta
+
+from src.contracts import (
+    ProgramExercise,
+    SessionStatus,
+    SourceType,
+    TrainingDay,
+    TrainingProgram,
+    TrainingWeek,
+    WorkoutSession,
+)
+from src.sensing.manual_input import manual_completed_set, manual_rep_event
+
+
+def _demo_manual_logging():
+    program = TrainingProgram(
+        program_id="prog-lower-a",
+        user_id="demo-user",
+        title="Lower A (demo)",
+        source_type=SourceType.TEXT,
+        weeks=[
+            TrainingWeek(
+                week_number=1,
+                days=[
+                    TrainingDay(
+                        day_id="day-lower-a",
+                        title="Lower A",
+                        exercises=[
+                            ProgramExercise(
+                                exercise_id="back_squat",
+                                display_name="Back Squat",
+                                set_count=3,
+                                rep_target="5",
+                                load_target="185",
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+        parse_confidence=1.0,
+        needs_user_confirmation=False,
+    )
+
+    session = WorkoutSession(
+        session_id="sess-manual-demo-1",
+        program_id=program.program_id,
+        day_id=program.weeks[0].days[0].day_id,
+        status=SessionStatus.IN_PROGRESS,
+        started_at=datetime.now(),
+    )
+
+    tap = manual_rep_event("back_squat", rep_index=1, session=session)
+    started = datetime.now()
+    first_set = manual_completed_set(
+        "back_squat",
+        set_number=1,
+        actual_reps=5,
+        started_at=started,
+        ended_at=started + timedelta(seconds=20),
+        target_reps=5,
+        actual_load=185.0,
+        target_load=185.0,
+        actual_rpe=7.5,
+        session=session,
+    )
+
+    print(f"program:   {program.title} ({program.program_id})")
+    print(f"session:   {session.session_id} status={session.status.value}")
+    print(f"rep tap:   {tap.exercise_id} rep={tap.rep_index} source={tap.source.value}")
+    print(
+        "set log:   "
+        f"{first_set.exercise_id} set#{first_set.set_number} "
+        f"{first_set.actual_reps} reps @ {first_set.actual_load} lb "
+        f"source={first_set.completion_source.value}"
+    )
+
+
 def main():
+    if "--demo-manual" in sys.argv:
+        _demo_manual_logging()
+        return
+
     print("Team 13 scaffold is set up.")
     print("See docs/team-plan.md for ownership and shared folders.")
     print("See docs/api-contracts.md for shared schemas.")
+    print("Run with --demo-manual to exercise the manual logging fallback.")
 
 
 if __name__ == "__main__":

--- a/src/sensing/manual_input.py
+++ b/src/sensing/manual_input.py
@@ -1,0 +1,96 @@
+"""Manual logging fallback for when automatic rep/set detection is unavailable.
+
+Exposes two pure helpers that produce the canonical runtime contracts with
+`MANUAL` source values:
+
+- `manual_rep_event`: emit a `RepEvent` for a tap-style manual rep log.
+- `manual_completed_set`: emit a `CompletedSet` for an end-of-set manual form.
+
+Both optionally accept a `WorkoutSession` so callers can enforce the
+session-level `manual_override_enabled` flag at the logging boundary.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from src.contracts import (
+    CompletedSet,
+    CompletionSource,
+    DetectionSource,
+    RepEvent,
+    WorkoutSession,
+)
+
+
+class ManualLoggingDisabledError(RuntimeError):
+    """Raised when manual input is attempted on a session with overrides disabled."""
+
+
+def _check_session(session: Optional[WorkoutSession]) -> None:
+    if session is not None and not session.manual_override_enabled:
+        raise ManualLoggingDisabledError(
+            f"session {session.session_id} has manual_override_enabled=False"
+        )
+
+
+def manual_rep_event(
+    exercise_id: str,
+    *,
+    rep_index: Optional[int] = None,
+    timestamp: Optional[datetime] = None,
+    session: Optional[WorkoutSession] = None,
+) -> RepEvent:
+    """Return a `RepEvent` representing a user-logged rep.
+
+    `rep_index` is optional — some UIs will not know the count at tap time and
+    leave the runtime to infer it. `timestamp` defaults to `datetime.now()`.
+    """
+
+    _check_session(session)
+    return RepEvent(
+        timestamp=timestamp or datetime.now(),
+        exercise_id=exercise_id,
+        event_type="rep_complete",
+        rep_index=rep_index,
+        source=DetectionSource.MANUAL,
+    )
+
+
+def manual_completed_set(
+    exercise_id: str,
+    set_number: int,
+    actual_reps: int,
+    *,
+    started_at: Optional[datetime] = None,
+    ended_at: Optional[datetime] = None,
+    target_reps: Optional[int] = None,
+    actual_load: Optional[float] = None,
+    target_load: Optional[float] = None,
+    actual_rpe: Optional[float] = None,
+    target_rpe: Optional[float] = None,
+    notes: Optional[str] = None,
+    session: Optional[WorkoutSession] = None,
+) -> CompletedSet:
+    """Return a `CompletedSet` representing a set the user logged by hand.
+
+    Missing `started_at` / `ended_at` default to `datetime.now()`; callers that
+    know real timestamps should pass them. Load and RPE fields are forwarded
+    as-is so the ingestion-side targets can be paired with the manual actuals.
+    """
+
+    _check_session(session)
+    now = datetime.now()
+    return CompletedSet(
+        exercise_id=exercise_id,
+        set_number=set_number,
+        target_reps=target_reps,
+        actual_reps=actual_reps,
+        target_load=target_load,
+        actual_load=actual_load,
+        target_rpe=target_rpe,
+        actual_rpe=actual_rpe,
+        started_at=started_at or now,
+        ended_at=ended_at or now,
+        completion_source=CompletionSource.MANUAL,
+        notes=notes,
+    )

--- a/tests/fixtures/sensor_events/manual_set_lower_a.json
+++ b/tests/fixtures/sensor_events/manual_set_lower_a.json
@@ -1,0 +1,99 @@
+{
+  "description": "A Lower A day logged entirely by hand — no IMU or camera data. Use for runtime/export integration tests that must function without live sensing.",
+  "session": {
+    "session_id": "sess-manual-demo-1",
+    "program_id": "prog-lower-a",
+    "day_id": "day-lower-a",
+    "status": "completed",
+    "manual_override_enabled": true
+  },
+  "rep_events": [
+    {
+      "timestamp": "2026-04-24T18:00:05",
+      "exercise_id": "back_squat",
+      "event_type": "rep_complete",
+      "rep_index": 1,
+      "source": "manual"
+    },
+    {
+      "timestamp": "2026-04-24T18:00:08",
+      "exercise_id": "back_squat",
+      "event_type": "rep_complete",
+      "rep_index": 2,
+      "source": "manual"
+    },
+    {
+      "timestamp": "2026-04-24T18:00:11",
+      "exercise_id": "back_squat",
+      "event_type": "rep_complete",
+      "rep_index": 3,
+      "source": "manual"
+    },
+    {
+      "timestamp": "2026-04-24T18:00:14",
+      "exercise_id": "back_squat",
+      "event_type": "rep_complete",
+      "rep_index": 4,
+      "source": "manual"
+    },
+    {
+      "timestamp": "2026-04-24T18:00:17",
+      "exercise_id": "back_squat",
+      "event_type": "rep_complete",
+      "rep_index": 5,
+      "source": "manual"
+    }
+  ],
+  "completed_sets": [
+    {
+      "exercise_id": "back_squat",
+      "set_number": 1,
+      "target_reps": 5,
+      "actual_reps": 5,
+      "target_load": 185.0,
+      "actual_load": 185.0,
+      "target_rpe": 7.5,
+      "actual_rpe": 7.5,
+      "started_at": "2026-04-24T18:00:00",
+      "ended_at": "2026-04-24T18:00:20",
+      "completion_source": "manual",
+      "notes": "felt strong"
+    },
+    {
+      "exercise_id": "back_squat",
+      "set_number": 2,
+      "target_reps": 5,
+      "actual_reps": 5,
+      "target_load": 185.0,
+      "actual_load": 185.0,
+      "started_at": "2026-04-24T18:02:30",
+      "ended_at": "2026-04-24T18:02:52",
+      "completion_source": "manual"
+    },
+    {
+      "exercise_id": "back_squat",
+      "set_number": 3,
+      "target_reps": 5,
+      "actual_reps": 4,
+      "target_load": 185.0,
+      "actual_load": 185.0,
+      "target_rpe": 8.5,
+      "actual_rpe": 9.0,
+      "started_at": "2026-04-24T18:05:10",
+      "ended_at": "2026-04-24T18:05:34",
+      "completion_source": "manual",
+      "notes": "missed last rep, form broke"
+    },
+    {
+      "exercise_id": "romanian_deadlift",
+      "set_number": 1,
+      "target_reps": 8,
+      "actual_reps": 8,
+      "target_load": 135.0,
+      "actual_load": 135.0,
+      "started_at": "2026-04-24T18:10:00",
+      "ended_at": "2026-04-24T18:10:28",
+      "completion_source": "manual"
+    }
+  ]
+}

--- a/tests/sensing/test_manual_input.py
+++ b/tests/sensing/test_manual_input.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from src.contracts import (
+    CompletedSet,
+    CompletionSource,
+    DetectionSource,
+    RepEvent,
+    WorkoutSession,
+)
+from src.sensing.manual_input import (
+    ManualLoggingDisabledError,
+    manual_completed_set,
+    manual_rep_event,
+)
+
+
+def test_manual_rep_event_defaults_and_source():
+    event = manual_rep_event("back_squat", rep_index=3)
+
+    assert isinstance(event, RepEvent)
+    assert event.exercise_id == "back_squat"
+    assert event.rep_index == 3
+    assert event.source is DetectionSource.MANUAL
+    assert event.event_type == "rep_complete"
+
+
+def test_manual_rep_event_accepts_explicit_timestamp():
+    ts = datetime(2026, 4, 24, 12, 0, 0)
+    event = manual_rep_event("bench_press", timestamp=ts)
+
+    assert event.timestamp == ts
+    assert event.rep_index is None
+
+
+def test_manual_completed_set_golden_path():
+    started = datetime(2026, 4, 24, 12, 0, 0)
+    ended = started + timedelta(seconds=45)
+
+    completed = manual_completed_set(
+        "back_squat",
+        set_number=1,
+        actual_reps=5,
+        started_at=started,
+        ended_at=ended,
+        target_reps=5,
+        actual_load=185.0,
+        target_load=185.0,
+        actual_rpe=7.5,
+        notes="felt strong",
+    )
+
+    assert isinstance(completed, CompletedSet)
+    assert completed.completion_source is CompletionSource.MANUAL
+    assert completed.actual_reps == 5
+    assert completed.actual_load == 185.0
+    assert completed.started_at == started
+    assert completed.ended_at == ended
+    assert completed.notes == "felt strong"
+
+
+def test_manual_completed_set_defaults_timestamps_to_now():
+    before = datetime.now()
+    completed = manual_completed_set("deadlift", set_number=2, actual_reps=3)
+    after = datetime.now()
+
+    assert before <= completed.started_at <= after
+    assert before <= completed.ended_at <= after
+
+
+def test_manual_completed_set_rejects_invalid_reps():
+    with pytest.raises(ValidationError):
+        manual_completed_set("back_squat", set_number=1, actual_reps=-1)
+
+
+def test_manual_rep_event_rejects_invalid_rep_index():
+    with pytest.raises(ValidationError):
+        manual_rep_event("back_squat", rep_index=0)
+
+
+def test_manual_logging_blocked_when_override_disabled():
+    session = WorkoutSession(
+        session_id="s1",
+        program_id="p1",
+        day_id="day-1",
+        manual_override_enabled=False,
+    )
+
+    with pytest.raises(ManualLoggingDisabledError):
+        manual_rep_event("back_squat", session=session)
+
+    with pytest.raises(ManualLoggingDisabledError):
+        manual_completed_set(
+            "back_squat", set_number=1, actual_reps=5, session=session
+        )
+
+
+def test_manual_logging_allowed_when_override_enabled():
+    session = WorkoutSession(session_id="s1", program_id="p1", day_id="day-1")
+
+    assert session.manual_override_enabled is True
+    event = manual_rep_event("back_squat", rep_index=1, session=session)
+    completed = manual_completed_set(
+        "back_squat", set_number=1, actual_reps=5, session=session
+    )
+
+    assert event.source is DetectionSource.MANUAL
+    assert completed.completion_source is CompletionSource.MANUAL


### PR DESCRIPTION
## Summary
- `src/sensing/manual_input.py` — `manual_rep_event()` and `manual_completed_set()` pure helpers that emit `RepEvent` / `CompletedSet` with `MANUAL` source values. Respect `WorkoutSession.manual_override_enabled` (raise `ManualLoggingDisabledError` when false).
- `src/main.py --demo-manual` — runs the helpers end-to-end against a minimal `TrainingProgram` / `WorkoutSession` so the feature is demoable without any sensing/runtime infra.
- `tests/sensing/test_manual_input.py` — 8 tests covering golden paths, timestamp defaults, pydantic validation, and the override-disabled block path. Baseline contract tests still pass (10/10 green).
- `tests/fixtures/sensor_events/manual_set_lower_a.json` — sample Lower A day logged entirely by hand, for downstream runtime/export integration tests.
- `.gitignore` — add `.venv/` and `*.egg-info/`.

## Why this now
- Closes issue #25 (Person 3 / sensing fallback responsibility per `docs/team-plan.md:60`).
- Unblocks Callum's runtime state-machine work and Alexander/Gavin's glasses work: they can drive the pipeline with manual-source `RepEvent` / `CompletedSet` objects until real sensing lands.
- No contract changes — the fields (`CompletionSource.MANUAL`, `DetectionSource.MANUAL`, `WorkoutSession.manual_override_enabled`) are already in `src/contracts/`. `docs/api-contracts.md:53` explicitly asked for manual fallbacks to be represented, not assumed.

## Test plan
- [x] `pytest tests` — 10/10 green (2 existing contract smoke + 8 new)
- [x] `python -m src.main --demo-manual` prints a clean rep-tap + set-log line
- [x] `python -m src.main` (default path) unchanged banner output
- [ ] Runtime team to integrate: consume `manual_rep_event` / `manual_completed_set` from the session engine when `manual_override_enabled` is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)