### PR TITLE
Add Parsing screen with real document preview

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,14 +1,17 @@
 // 'entry' → 'parsing' → 'review' state machine.
-// Backend is unwired: the selected File is the only thing that flows between screens.
+// Backend is unwired: the selected File flows through to Parsing where it gets
+// previewed and faux-processed. parseProgram() is a single mockable seam in
+// lib/parseProgram.ts when real wiring lands.
 
 import { useState } from 'react';
 import { EntryScreen } from './screens/EntryScreen';
+import { ParsingScreen } from './screens/ParsingScreen';
 
 type Step = 'entry' | 'parsing' | 'review';
 
 export default function App() {
   const [step, setStep] = useState<Step>('entry');
-  const [, setFile] = useState<File | null>(null);
+  const [file, setFile] = useState<File | null>(null);
 
   const handleFileSelected = (f: File) => {
     setFile(f);
@@ -18,11 +21,14 @@ export default function App() {
   if (step === 'entry') {
     return <EntryScreen onFileSelected={handleFileSelected} />;
   }
-  // Parsing + Review screens land in subsequent commits/branches.
+  if (step === 'parsing' && file) {
+    return <ParsingScreen file={file} onDone={() => setStep('review')} />;
+  }
+  // Review screen lands in the next branch.
   return (
     <div style={{ padding: 40, color: 'var(--text-1)' }}>
       <h1 style={{ fontFamily: 'var(--font-sans)' }}>step: {step}</h1>
-      <p style={{ color: 'var(--text-2)' }}>Stub — Parsing/Review screens land in next branches.</p>
+      <p style={{ color: 'var(--text-2)' }}>Stub — Review screen lands in app/desktop-add-program-review.</p>
       <button onClick={() => setStep('entry')}>Back to entry</button>
     </div>
   );

--- a/desktop/src/data/sample.ts
+++ b/desktop/src/data/sample.ts
@@ -1,0 +1,77 @@
+// Sample Day-1 program for the demo. Used by the Parsing screen's "What we found"
+// card and the Review screen's exercise table — single source of truth so the two
+// screens stay in agreement.
+
+import { SourceType, type ProgramExercise, type TrainingDay, type TrainingProgram } from '../lib/types';
+
+const day1Exercises: ProgramExercise[] = [
+  {
+    exercise_id: 'bench-press',
+    display_name: 'Bench Press',
+    set_count: 4,
+    rep_target: '4',
+    load_target: '225 lb',
+    notes: 'Top set, leave 2 in reserve',
+    ambiguity_flags: [],
+  },
+  {
+    exercise_id: 'incline-db-press',
+    display_name: 'Incline Dumbbell Press',
+    set_count: 3,
+    rep_target: '8-10',
+    load_target: '70 lb',
+    notes: 'Pause at bottom',
+    ambiguity_flags: [],
+  },
+  {
+    exercise_id: 'weighted-dip',
+    display_name: 'Weighted Dip',
+    set_count: 3,
+    rep_target: '6-8',
+    load_target: 'BW + 45 lb',
+    notes: 'Lean forward · chest focus',
+    ambiguity_flags: [],
+  },
+  {
+    exercise_id: 'cable-fly',
+    display_name: 'Cable Fly',
+    set_count: 3,
+    rep_target: '12-15',
+    load_target: '30 lb',
+    notes: 'Slow eccentric',
+    ambiguity_flags: [],
+  },
+  {
+    exercise_id: 'tricep-pushdown',
+    display_name: 'Tricep Pushdown',
+    set_count: 3,
+    rep_target: '10-12',
+    load_target: '60 lb',
+    ambiguity_flags: [],
+  },
+];
+
+const day1: TrainingDay = {
+  day_id: 'day-1',
+  title: 'Heavy Push',
+  exercises: day1Exercises,
+};
+
+export const sampleProgram: TrainingProgram = {
+  program_id: 'powerbuilding-5x',
+  user_id: 'demo-user',
+  title: 'Powerbuilding 5x',
+  source_type: SourceType.IMAGE,
+  weeks: [{ week_number: 1, days: [day1] }],
+  parse_confidence: 0.94,
+  needs_user_confirmation: true,
+};
+
+// Headline copy for the Parsing screen "What we found" card and demo display.
+export const sampleProgramMeta = {
+  author: 'Jeff Nippard',
+  title: sampleProgram.title,
+  workouts: 23,
+  sets: 78,
+  notes: 14,
+};

--- a/desktop/src/lib/parseProgram.ts
+++ b/desktop/src/lib/parseProgram.ts
@@ -1,0 +1,21 @@
+// Single seam for the backend parser. Today this is a setTimeout that returns
+// the hardcoded sample. When Person 2's ingestion path is ready, swap the
+// implementation for a real fetch — the call sites in ParsingScreen / App
+// don't need to change.
+
+import { sampleProgram } from '../data/sample';
+import type { TrainingProgram } from './types';
+
+export interface ParseProgramOptions {
+  /** How long the mock parse should take, in ms. Defaults to 2800ms. */
+  delayMs?: number;
+}
+
+export async function parseProgram(
+  _file: File,
+  { delayMs = 2800 }: ParseProgramOptions = {},
+): Promise<TrainingProgram> {
+  // The mock ignores file content for now. Real backend will read it.
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+  return sampleProgram;
+}

--- a/desktop/src/lib/pdfPreview.ts
+++ b/desktop/src/lib/pdfPreview.ts
@@ -1,0 +1,45 @@
+// Render the first page of a PDF File to a data URL using pdfjs-dist.
+// Lazy-imported so the ~200KB pdfjs bundle only loads when a PDF is uploaded.
+
+export interface PdfPreviewResult {
+  dataUrl: string;
+  width: number;
+  height: number;
+}
+
+export async function renderPdfFirstPage(file: File, targetWidth = 800): Promise<PdfPreviewResult> {
+  // Lazy import — keeps the entry-screen bundle slim.
+  const pdfjs = await import('pdfjs-dist');
+
+  // pdfjs needs a worker URL set once. Resolve via Vite ?url; fall back to CDN.
+  if (!pdfjs.GlobalWorkerOptions.workerSrc) {
+    try {
+      const workerUrl = (await import('pdfjs-dist/build/pdf.worker.min.mjs?url')).default;
+      pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+    } catch {
+      pdfjs.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+    }
+  }
+
+  const buf = await file.arrayBuffer();
+  const doc = await pdfjs.getDocument({ data: buf }).promise;
+  const page = await doc.getPage(1);
+
+  const viewport1x = page.getViewport({ scale: 1 });
+  const scale = targetWidth / viewport1x.width;
+  const viewport = page.getViewport({ scale });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.ceil(viewport.width);
+  canvas.height = Math.ceil(viewport.height);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('PDF preview: could not get canvas 2d context');
+
+  await page.render({ canvasContext: ctx, viewport, canvas }).promise;
+
+  return {
+    dataUrl: canvas.toDataURL('image/png'),
+    width: canvas.width,
+    height: canvas.height,
+  };
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -1,0 +1,45 @@
+// 1:1 mirror of src/contracts/program.py — keep these in sync if the Python
+// contracts move. Used by the mock parser stub and the Review screen.
+
+export const SourceType = {
+  IMAGE: 'image',
+  PDF: 'pdf',
+  SPREADSHEET: 'spreadsheet',
+  TEXT: 'text',
+  GENERATED: 'generated',
+} as const;
+export type SourceType = (typeof SourceType)[keyof typeof SourceType];
+
+export interface ProgramExercise {
+  exercise_id: string;
+  display_name: string;
+  set_count: number;
+  rep_target?: string;
+  load_target?: string;
+  rpe_target?: number;
+  rest_seconds?: number;
+  notes?: string;
+  ambiguity_flags: string[];
+}
+
+export interface TrainingDay {
+  day_id: string;
+  title: string;
+  exercises: ProgramExercise[];
+  notes?: string;
+}
+
+export interface TrainingWeek {
+  week_number: number;
+  days: TrainingDay[];
+}
+
+export interface TrainingProgram {
+  program_id: string;
+  user_id: string;
+  title: string;
+  source_type: SourceType;
+  weeks: TrainingWeek[];
+  parse_confidence?: number;
+  needs_user_confirmation: boolean;
+}

--- a/desktop/src/screens/ParsingScreen.tsx
+++ b/desktop/src/screens/ParsingScreen.tsx
@@ -1,0 +1,428 @@
+// "Parse" step of the Add Program flow.
+// Ported from screens-desktop.jsx DesktopParsingScreen (lines 617-785).
+//
+// Two intentional swaps from the design:
+//   - The mock paper preview is replaced with a real preview of the uploaded file.
+//     Images render via URL.createObjectURL; PDFs render page 1 via pdfjs-dist;
+//     spreadsheets/unknowns fall back to a centered "Preview unavailable" card.
+//   - The phase animation is driven by setInterval (~700ms cadence) so the screen
+//     auto-advances to Review after ~3s.
+
+import { useEffect, useMemo, useState } from 'react';
+import { ContentHeader } from '../components/ContentHeader';
+import { DesktopWindow } from '../components/DesktopWindow';
+import { Icon } from '../components/ui/Icon';
+import { sampleProgramMeta } from '../data/sample';
+import { renderPdfFirstPage } from '../lib/pdfPreview';
+import { classifyFile, formatBytes, type FileKind } from '../lib/upload';
+
+const PHASES = [
+  'Reading the page',
+  'Identifying structure',
+  'Mapping workouts',
+  'Building schedule',
+] as const;
+
+const PHASE_INTERVAL_MS = 700;
+
+interface ParsingScreenProps {
+  file: File;
+  onDone: () => void;
+}
+
+export function ParsingScreen({ file, onDone }: ParsingScreenProps) {
+  const kind: FileKind = useMemo(() => classifyFile(file), [file]);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [phase, setPhase] = useState(0);
+
+  // Build the preview URL (image / pdf / fallback).
+  useEffect(() => {
+    let cancelled = false;
+    let revokable: string | null = null;
+
+    async function build() {
+      if (kind === 'image') {
+        const url = URL.createObjectURL(file);
+        revokable = url;
+        if (!cancelled) setPreviewUrl(url);
+        return;
+      }
+      if (kind === 'pdf') {
+        try {
+          const { dataUrl } = await renderPdfFirstPage(file);
+          if (!cancelled) setPreviewUrl(dataUrl);
+        } catch (err) {
+          if (!cancelled) setPreviewError(err instanceof Error ? err.message : 'PDF preview failed');
+        }
+        return;
+      }
+      // sheet/unknown: leave previewUrl null and let the fallback render.
+    }
+
+    build();
+    return () => {
+      cancelled = true;
+      if (revokable) URL.revokeObjectURL(revokable);
+    };
+  }, [file, kind]);
+
+  // Drive the phase animation. After the last phase ticks complete, auto-advance.
+  useEffect(() => {
+    if (phase >= PHASES.length) {
+      const t = setTimeout(onDone, 600);
+      return () => clearTimeout(t);
+    }
+    const t = setTimeout(() => setPhase((p) => p + 1), PHASE_INTERVAL_MS);
+    return () => clearTimeout(t);
+  }, [phase, onDone]);
+
+  return (
+    <DesktopWindow active="add" title="Parsing">
+      <ContentHeader
+        step={1}
+        title="Parsing your program"
+        subtitle="Hang tight — we're reading the page and matching it to known workouts."
+      />
+      <div style={{ padding: 36, display: 'flex', gap: 24, height: 'calc(100% - 100px)' }}>
+        {/* Left — source preview */}
+        <div
+          style={{
+            flex: 1,
+            borderRadius: 16,
+            overflow: 'hidden',
+            background: 'var(--surface-1)',
+            border: '1px solid var(--hairline)',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <div
+            style={{
+              padding: '12px 16px',
+              borderBottom: '1px solid var(--hairline)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+              <Icon name="file" size={14} stroke="var(--text-2)" />
+              <span
+                style={{
+                  fontSize: 12,
+                  color: 'var(--text-2)',
+                  fontWeight: 500,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={file.name}
+              >
+                {file.name}
+              </span>
+              <span className="mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>
+                · {formatBytes(file.size)}
+              </span>
+              {kind === 'pdf' && (
+                <span
+                  className="mono"
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--accent)',
+                    background: 'var(--accent-soft)',
+                    border: '1px solid rgba(197,242,62,0.3)',
+                    padding: '2px 8px',
+                    borderRadius: 9999,
+                    marginLeft: 6,
+                    flexShrink: 0,
+                  }}
+                >
+                  Page 1
+                </span>
+              )}
+            </div>
+            <div style={{ display: 'flex', gap: 4 }}>
+              {(['minus', 'plus', 'maximize'] as const).map((b) => (
+                <button
+                  key={b}
+                  type="button"
+                  style={{
+                    width: 26,
+                    height: 26,
+                    borderRadius: 6,
+                    background: 'transparent',
+                    border: 'none',
+                    color: 'var(--text-3)',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Icon name={b} size={14} />
+                </button>
+              ))}
+            </div>
+          </div>
+          <div
+            style={{
+              flex: 1,
+              padding: 28,
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background:
+                'repeating-linear-gradient(45deg, rgba(255,255,255,0.015) 0 12px, rgba(255,255,255,0.025) 12px 24px)',
+              overflow: 'hidden',
+            }}
+          >
+            {previewUrl ? (
+              <>
+                <img
+                  src={previewUrl}
+                  alt={file.name}
+                  style={{
+                    maxWidth: '100%',
+                    maxHeight: '100%',
+                    width: 'auto',
+                    height: 'auto',
+                    objectFit: 'contain',
+                    borderRadius: 8,
+                    boxShadow: '0 16px 48px rgba(0,0,0,0.4)',
+                    background: '#fff',
+                  }}
+                />
+                {/* Lime scan-sweep overlay */}
+                <div
+                  className="scan-sweep"
+                  style={{
+                    position: 'absolute',
+                    left: 28,
+                    right: 28,
+                    height: 40,
+                    top: '40%',
+                    background:
+                      'linear-gradient(180deg, transparent, rgba(197,242,62,0.4), transparent)',
+                    pointerEvents: 'none',
+                  }}
+                />
+              </>
+            ) : (
+              <PreviewFallback file={file} kind={kind} error={previewError} />
+            )}
+          </div>
+        </div>
+
+        {/* Right — progress + findings */}
+        <div style={{ width: 380, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          {/* Phases */}
+          <div
+            style={{
+              borderRadius: 16,
+              padding: 20,
+              background: 'var(--surface-1)',
+              border: '1px solid var(--hairline)',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--text-3)',
+                textTransform: 'uppercase',
+                letterSpacing: 0.8,
+                fontWeight: 600,
+                marginBottom: 14,
+              }}
+            >
+              Progress
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+              {PHASES.map((label, i) => {
+                const done = i < phase;
+                const active = i === phase;
+                return (
+                  <div key={label} style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+                    <div
+                      style={{
+                        width: 22,
+                        height: 22,
+                        borderRadius: 9999,
+                        flexShrink: 0,
+                        background: done
+                          ? 'var(--accent)'
+                          : active
+                            ? 'transparent'
+                            : 'var(--surface-2)',
+                        border:
+                          '1.5px solid ' +
+                          (done ? 'var(--accent)' : active ? 'var(--accent)' : 'var(--hairline-2)'),
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        position: 'relative',
+                      }}
+                    >
+                      {done && (
+                        <Icon name="check" size={12} stroke="var(--on-accent)" strokeWidth={3} />
+                      )}
+                      {active && (
+                        <div
+                          className="spin-ring"
+                          style={{
+                            position: 'absolute',
+                            inset: -2,
+                            borderRadius: '50%',
+                            border: '2px solid transparent',
+                            borderTopColor: 'var(--accent)',
+                          }}
+                        />
+                      )}
+                    </div>
+                    <div style={{ flex: 1, paddingTop: 1 }}>
+                      <div
+                        style={{
+                          fontSize: 13.5,
+                          fontWeight: 600,
+                          color: done || active ? 'var(--text-1)' : 'var(--text-3)',
+                        }}
+                      >
+                        {label}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Live findings */}
+          <div
+            style={{
+              borderRadius: 16,
+              padding: 20,
+              background: 'var(--hero-bg)',
+              border: '1px solid var(--hero-border)',
+              position: 'relative',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--accent)',
+                textTransform: 'uppercase',
+                letterSpacing: 0.8,
+                fontWeight: 600,
+                marginBottom: 12,
+              }}
+            >
+              What we found
+            </div>
+            <div style={{ fontSize: 22, fontWeight: 600, letterSpacing: -0.4, marginBottom: 4 }}>
+              {sampleProgramMeta.title}
+            </div>
+            <div style={{ fontSize: 13, color: 'var(--text-2)', marginBottom: 16 }}>
+              by {sampleProgramMeta.author}
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10 }}>
+              {[
+                { v: sampleProgramMeta.workouts, l: 'Workouts' },
+                { v: sampleProgramMeta.sets, l: 'Sets' },
+                { v: sampleProgramMeta.notes, l: 'Notes' },
+              ].map((s) => (
+                <div
+                  key={s.l}
+                  style={{
+                    padding: 12,
+                    borderRadius: 10,
+                    background: 'var(--overlay-1)',
+                    border: '1px solid var(--hairline)',
+                    textAlign: 'center',
+                  }}
+                >
+                  <div
+                    className="mono"
+                    style={{ fontSize: 22, fontWeight: 600, color: 'var(--accent)' }}
+                  >
+                    {s.v}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 10,
+                      color: 'var(--text-3)',
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.4,
+                      marginTop: 2,
+                    }}
+                  >
+                    {s.l}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </DesktopWindow>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Fallback preview card for spreadsheets / unknown types / pdf-render errors.
+// ─────────────────────────────────────────────────────────────
+interface PreviewFallbackProps {
+  file: File;
+  kind: FileKind;
+  error: string | null;
+}
+
+function PreviewFallback({ file, kind, error }: PreviewFallbackProps) {
+  const label =
+    kind === 'sheet'
+      ? 'Preview unavailable for spreadsheets'
+      : kind === 'pdf'
+        ? 'PDF preview unavailable'
+        : 'Preview unavailable for this file type';
+  const sub =
+    error
+      ? error
+      : kind === 'sheet'
+        ? "Full data lands in the parsed table on the next step."
+        : 'The parser will still process this file.';
+  const glyph: 'image' | 'file' = kind === 'sheet' ? 'file' : 'file';
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+        textAlign: 'center',
+        maxWidth: 360,
+      }}
+    >
+      <div
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 16,
+          background: 'var(--surface-2)',
+          border: '1px solid var(--hairline)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Icon name={glyph} size={32} stroke="var(--text-2)" />
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--text-1)' }}>{label}</div>
+      <div style={{ fontSize: 12.5, color: 'var(--text-3)' }}>{sub}</div>
+      <div className="mono" style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 6 }}>
+        {file.name} · {formatBytes(file.size)}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements the program parsing screen for issue #36. Stacked on #39.

Adds TS types under `desktop/src/lib/types.ts` mirroring `src/contracts/program.py`
Drops a hardcoded Powerbuilding 5x Day-1 sample so Parsing and Review share one source of truth
Adds a `parseProgram` async stub as the seam for the real backend
Adds a lazy `pdfjs-dist` helper that renders page 1 of an uploaded PDF to a data URL
Builds ParsingScreen with the design's split layout, but swaps the mock paper placeholder for a real preview of the uploaded file — images via `URL.createObjectURL`, PDFs via the helper above, and a fallback card for spreadsheets and unknown types
Drives 4 progress phases on a 700ms interval, with the spinner-ring → checkmark transition, before auto-advancing to Review