### PR TITLE
Add Review screen with parsed program table

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,11 +1,12 @@
 // 'entry' → 'parsing' → 'review' state machine.
-// Backend is unwired: the selected File flows through to Parsing where it gets
-// previewed and faux-processed. parseProgram() is a single mockable seam in
-// lib/parseProgram.ts when real wiring lands.
+// Backend is unwired: the selected File flows through Parsing where it gets
+// previewed and faux-processed; Review reads its rows from data/sample.ts.
+// parseProgram() in lib/parseProgram.ts is the single seam for real wiring.
 
 import { useState } from 'react';
 import { EntryScreen } from './screens/EntryScreen';
 import { ParsingScreen } from './screens/ParsingScreen';
+import { ReviewScreen } from './screens/ReviewScreen';
 
 type Step = 'entry' | 'parsing' | 'review';
 
@@ -18,18 +19,20 @@ export default function App() {
     setStep('parsing');
   };
 
+  const handleSave = () => {
+    // Save & sync to glasses is a no-op for the demo. Reset for the next take.
+    setFile(null);
+    setStep('entry');
+  };
+
   if (step === 'entry') {
     return <EntryScreen onFileSelected={handleFileSelected} />;
   }
   if (step === 'parsing' && file) {
     return <ParsingScreen file={file} onDone={() => setStep('review')} />;
   }
-  // Review screen lands in the next branch.
-  return (
-    <div style={{ padding: 40, color: 'var(--text-1)' }}>
-      <h1 style={{ fontFamily: 'var(--font-sans)' }}>step: {step}</h1>
-      <p style={{ color: 'var(--text-2)' }}>Stub — Review screen lands in app/desktop-add-program-review.</p>
-      <button onClick={() => setStep('entry')}>Back to entry</button>
-    </div>
-  );
+  if (step === 'review') {
+    return <ReviewScreen onSave={handleSave} />;
+  }
+  return null;
 }

--- a/desktop/src/screens/ReviewScreen.tsx
+++ b/desktop/src/screens/ReviewScreen.tsx
@@ -1,0 +1,72 @@
+// "Review" step of the Add Program flow.
+// Ported from screens-desktop.jsx DesktopReviewScreen (lines 790-906).
+
+import { ContentHeader } from '../components/ContentHeader';
+import { DesktopWindow } from '../components/DesktopWindow';
+import { Icon } from '../components/ui/Icon';
+import { sampleProgram } from '../data/sample';
+
+interface ReviewScreenProps {
+  onSave: () => void;
+}
+
+export function ReviewScreen(_props: ReviewScreenProps) {
+  const day = sampleProgram.weeks[0]?.days[0];
+
+  return (
+    <DesktopWindow active="add" title="Review">
+      <ContentHeader
+        step={2}
+        title="Review parsed program"
+        subtitle="Edit anything that looks off, then send to your glasses."
+      />
+      <div style={{ padding: 36 }}>
+        {/* Day header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 16,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--text-3)',
+                textTransform: 'uppercase',
+                letterSpacing: 0.8,
+                fontWeight: 600,
+              }}
+            >
+              Day 1
+            </div>
+            <div style={{ fontSize: 22, fontWeight: 600, letterSpacing: -0.4, marginTop: 2 }}>
+              {day?.title ?? 'Heavy Push'}
+            </div>
+          </div>
+          <button
+            type="button"
+            style={{
+              background: 'var(--surface-2)',
+              border: '1px solid var(--hairline)',
+              color: 'var(--text-2)',
+              borderRadius: 8,
+              padding: '6px 12px',
+              fontSize: 12,
+              cursor: 'pointer',
+              fontFamily: 'var(--font-sans)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            <Icon name="plus" size={12} />
+            Add workout
+          </button>
+        </div>
+      </div>
+    </DesktopWindow>
+  );
+}

--- a/desktop/src/screens/ReviewScreen.tsx
+++ b/desktop/src/screens/ReviewScreen.tsx
@@ -12,13 +12,15 @@ interface ReviewScreenProps {
 
 export function ReviewScreen({ onSave }: ReviewScreenProps) {
   const day = sampleProgram.weeks[0]?.days[0];
+  const exercises = day?.exercises ?? [];
+  const totalSets = exercises.reduce((sum, ex) => sum + ex.set_count, 0);
 
   return (
     <DesktopWindow active="add" title="Review">
       <ContentHeader
         step={2}
         title="Review parsed program"
-        subtitle="Edit anything that looks off, then send to your glasses."
+        subtitle={`${exercises.length} workouts, ${totalSets} sets across the day. Edit anything that looks off, then send to your glasses.`}
         right={
           <button
             type="button"
@@ -89,6 +91,114 @@ export function ReviewScreen({ onSave }: ReviewScreenProps) {
             <Icon name="plus" size={12} />
             Add workout
           </button>
+        </div>
+
+        {/* Table */}
+        <div
+          style={{
+            borderRadius: 14,
+            overflow: 'hidden',
+            background: 'var(--surface-1)',
+            border: '1px solid var(--hairline)',
+          }}
+        >
+          {/* Header row */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '2.2fr 0.5fr 0.7fr 0.9fr 2.4fr 36px',
+              padding: '10px 16px',
+              gap: 12,
+              background: 'var(--surface-2)',
+              borderBottom: '1px solid var(--hairline)',
+              fontSize: 10.5,
+              color: 'var(--text-3)',
+              textTransform: 'uppercase',
+              letterSpacing: 0.6,
+              fontWeight: 700,
+            }}
+          >
+            <div>Workout</div>
+            <div>Sets</div>
+            <div>Reps</div>
+            <div>Weight</div>
+            <div>Notes</div>
+            <div></div>
+          </div>
+          {exercises.map((ex, i) => (
+            <div
+              key={ex.exercise_id}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '2.2fr 0.5fr 0.7fr 0.9fr 2.4fr 36px',
+                padding: '14px 16px',
+                gap: 12,
+                alignItems: 'center',
+                borderBottom: i < exercises.length - 1 ? '1px solid var(--hairline)' : 'none',
+                fontSize: 13,
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: 8,
+                    background: 'var(--accent-soft)',
+                    border: '1px solid rgba(197,242,62,0.2)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: 'var(--accent)',
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                >
+                  {i + 1}
+                </div>
+                <div style={{ fontWeight: 600 }}>{ex.display_name}</div>
+              </div>
+              <div className="mono" style={{ color: 'var(--text-1)' }}>
+                {ex.set_count}
+              </div>
+              <div className="mono" style={{ color: 'var(--text-1)' }}>
+                {ex.rep_target ?? '—'}
+              </div>
+              <div className="mono" style={{ color: 'var(--text-1)' }}>
+                {ex.load_target ?? '—'}
+              </div>
+              <div
+                style={{
+                  fontSize: 12.5,
+                  color: ex.notes ? 'var(--text-2)' : 'var(--text-3)',
+                  fontStyle: ex.notes ? 'normal' : 'italic',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {ex.notes || 'Add a note…'}
+              </div>
+              <button
+                type="button"
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 6,
+                  background: 'transparent',
+                  border: 'none',
+                  color: 'var(--text-3)',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Icon name="more-horizontal" size={14} />
+              </button>
+            </div>
+          ))}
         </div>
       </div>
     </DesktopWindow>

--- a/desktop/src/screens/ReviewScreen.tsx
+++ b/desktop/src/screens/ReviewScreen.tsx
@@ -10,7 +10,7 @@ interface ReviewScreenProps {
   onSave: () => void;
 }
 
-export function ReviewScreen(_props: ReviewScreenProps) {
+export function ReviewScreen({ onSave }: ReviewScreenProps) {
   const day = sampleProgram.weeks[0]?.days[0];
 
   return (
@@ -19,6 +19,30 @@ export function ReviewScreen(_props: ReviewScreenProps) {
         step={2}
         title="Review parsed program"
         subtitle="Edit anything that looks off, then send to your glasses."
+        right={
+          <button
+            type="button"
+            onClick={onSave}
+            className="press"
+            style={{
+              background: 'var(--accent)',
+              color: 'var(--on-accent)',
+              border: 'none',
+              padding: '10px 18px',
+              borderRadius: 9999,
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+              fontFamily: 'var(--font-sans)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            Save &amp; sync to glasses
+            <Icon name="arrow-right" size={14} stroke="var(--on-accent)" strokeWidth={2.2} />
+          </button>
+        }
       />
       <div style={{ padding: 36 }}>
         {/* Day header */}

--- a/desktop/src/screens/ReviewScreen.tsx
+++ b/desktop/src/screens/ReviewScreen.tsx
@@ -39,6 +39,7 @@ export function ReviewScreen({ onSave }: ReviewScreenProps) {
               display: 'flex',
               alignItems: 'center',
               gap: 6,
+              whiteSpace: 'nowrap',
             }}
           >
             Save &amp; sync to glasses


### PR DESCRIPTION
## Summary
Implements the parsed program review screen for issue #37. Stacked on #40.

Adds ReviewScreen with the Day-1 title row and a stub Add workout button
Adds the lime Save & sync to glasses CTA in the header
Renders a 6-column exercise table reading from the shared `sample.ts` (Workout / Sets / Reps / Weight / Notes / kebab)
Wires Save to reset App state back to entry so the demo loops cleanly — real persistence happens later via Person 1's runtime layer
Pins the CTA with whiteSpace: nowrap so the label doesn't wrap to two lines on narrower viewports