### PR TITLE
iOS signup flow UI

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,15 @@
+# iOS prototype
+
+iPhone-side of TrainAR. Currently just the signup flow — backend hookup comes later.
+
+To open it, just open `ios/index.html` in a browser. No build step. React + Babel are loaded from a CDN at the top of the HTML.
+
+## Layout
+
+- `index.html` — entry point, pulls in scripts in dependency order
+- `tokens.css` — design tokens (dark theme, lime accent)
+- `ui.jsx` — shared primitives (Icon, Button, Card, Input)
+- `ios-frame.jsx` — iPhone device frame (status bar, dynamic island, home indicator)
+- `screens-signup.jsx` — splash, auth, name screens
+- `auth.js` — `useAuth()` stub — swap with real backend later
+- `app.jsx` — wires the screens into the device frame

--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -1,0 +1,64 @@
+// App — wires the signup screens into the iPhone frame.
+//
+// Tiny state machine: 'splash' → 'auth' → 'name' → 'done'.
+// `mode` decides whether the auth screen opens in signup or sign-in mode.
+
+const PROTOTYPE_W = 402;
+const PROTOTYPE_H = 874;
+
+function App() {
+  const auth = useAuth();
+  const [screen, setScreen] = React.useState('splash');
+  const [mode, setMode] = React.useState('signup');
+
+  // If a returning user already has a name, skip ahead to "done" on first render.
+  // Easy to remove once the rest of the app exists to land them in.
+  React.useEffect(() => {
+    if (auth.user && auth.user.name && screen === 'splash') setScreen('done');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const restart = () => {
+    auth.signOut();
+    setScreen('splash');
+    setMode('signup');
+  };
+
+  const screens = {
+    splash: (
+      <SplashScreen
+        onSignUp={() => { setMode('signup'); setScreen('auth'); }}
+        onSignIn={() => { setMode('login');  setScreen('auth'); }}
+      />
+    ),
+    auth: (
+      <AuthScreen
+        auth={auth}
+        initialMode={mode}
+        onContinue={() => setScreen(mode === 'signup' ? 'name' : 'done')}
+        onBack={() => setScreen('splash')}
+      />
+    ),
+    name: (
+      <NameScreen
+        auth={auth}
+        onContinue={() => setScreen('done')}
+        onBack={() => setScreen('auth')}
+      />
+    ),
+    done: <DoneScreen auth={auth} onRestart={restart} />,
+  };
+
+  return (
+    <div style={{ padding: 32 }}>
+      <IOSDevice width={PROTOTYPE_W} height={PROTOTYPE_H} dark={true}>
+        <div style={{ width: '100%', height: '100%', position: 'relative', background: 'var(--bg)', color: 'var(--text-1)' }}>
+          {screens[screen]}
+        </div>
+      </IOSDevice>
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/ios/auth.js
+++ b/ios/auth.js
@@ -1,0 +1,92 @@
+// Auth hook stub.
+//
+// The screens never call a backend directly — they only talk to useAuth().
+// When a real backend is ready, replace the bodies of signUp/signIn/setName
+// with fetch calls. The shape of `user` should stay the same so the screens
+// don't need to change.
+//
+// Persists to localStorage so a refresh keeps you signed in.
+
+(function () {
+  const STORAGE_KEY = 'trainar.auth.v1';
+
+  const loadUser = () => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch (_e) {
+      return null;
+    }
+  };
+
+  const saveUser = (user) => {
+    try {
+      if (user) window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+      else window.localStorage.removeItem(STORAGE_KEY);
+    } catch (_e) { /* swallow — preview environments may block storage */ }
+  };
+
+  // Pretend to talk to a server.
+  const fakeDelay = (ms = 600) => new Promise((r) => setTimeout(r, ms));
+
+  // Tiny rules so the UI can show real-feeling validation errors.
+  const validateEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  const validatePassword = (pw) => typeof pw === 'string' && pw.length >= 8;
+
+  function useAuth() {
+    const [user, setUser] = React.useState(loadUser);
+    const [pending, setPending] = React.useState(false);
+    const [error, setError] = React.useState(null);
+
+    const signUp = async ({ email, password }) => {
+      setError(null);
+      if (!validateEmail(email))     { setError('Enter a valid email.'); return false; }
+      if (!validatePassword(password)) { setError('Password must be at least 8 characters.'); return false; }
+      setPending(true);
+      await fakeDelay();
+      const next = { id: 'local-' + Date.now(), email, name: null };
+      setUser(next); saveUser(next);
+      setPending(false);
+      return true;
+    };
+
+    const signIn = async ({ email, password }) => {
+      setError(null);
+      if (!validateEmail(email))     { setError('Enter a valid email.'); return false; }
+      if (!validatePassword(password)) { setError('Password must be at least 8 characters.'); return false; }
+      setPending(true);
+      await fakeDelay();
+      const next = { id: 'local-' + Date.now(), email, name: null };
+      setUser(next); saveUser(next);
+      setPending(false);
+      return true;
+    };
+
+    const setName = async (name) => {
+      if (!user) return false;
+      setPending(true);
+      await fakeDelay(300);
+      const next = { ...user, name };
+      setUser(next); saveUser(next);
+      setPending(false);
+      return true;
+    };
+
+    const signOut = () => { setUser(null); saveUser(null); };
+
+    return { user, pending, error, signUp, signIn, setName, signOut };
+  }
+
+  // Password strength scorer used by the signup form (0..4).
+  function scorePassword(pw) {
+    if (!pw) return 0;
+    let score = 0;
+    if (pw.length >= 8)  score++;
+    if (pw.length >= 12) score++;
+    if (/[A-Z]/.test(pw) && /[a-z]/.test(pw)) score++;
+    if (/[0-9]/.test(pw) || /[^A-Za-z0-9]/.test(pw)) score++;
+    return Math.min(score, 4);
+  }
+
+  Object.assign(window, { useAuth, scorePassword });
+})();

--- a/ios/index.html
+++ b/ios/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>TrainAR · iOS signup</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="tokens.css" />
+  <style>
+    html, body { margin: 0; padding: 0; background: var(--frame-bg); font-family: var(--font-sans); }
+    #root { width: 100vw; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <!-- React + Babel via CDN (no build step) -->
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
+
+  <!-- Auth stub — kept plain JS so it's easy to swap with a real backend later -->
+  <script src="auth.js"></script>
+
+  <!-- UI primitives, then the iOS frame, then the screens, then the app -->
+  <script type="text/babel" src="ui.jsx"></script>
+  <script type="text/babel" src="ios-frame.jsx"></script>
+  <script type="text/babel" src="screens-signup.jsx"></script>
+  <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/ios/ios-frame.jsx
+++ b/ios/ios-frame.jsx
@@ -1,0 +1,80 @@
+// Simplified iPhone frame — status bar + dynamic island + home indicator.
+// Matches the proportions used in the design handoff so screens drop in cleanly.
+
+function IOSStatusBar({ dark = true, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        {/* signal bars */}
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0"    y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8"  y="5"   width="3.2" height="7"   rx="0.7" fill={c}/>
+          <rect x="9.6"  y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0"   width="3.2" height="12"  rx="0.7" fill={c}/>
+        </svg>
+        {/* wifi */}
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        {/* battery */}
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2"   y="2"   width="20" height="9"  rx="2"   fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function IOSDevice({ children, width = 402, height = 874, dark = true }) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute, drawn above content) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+      </div>
+      {/* home indicator */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { IOSDevice, IOSStatusBar });

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -70,4 +70,120 @@ const SplashScreen = ({ onSignUp, onSignIn }) => (
   </Screen>
 );
 
-Object.assign(window, { Screen, SplashScreen });
+// ─────────────────────────────────────────────────────────────
+// 2. Auth — email + password, signup/login toggle.
+// ─────────────────────────────────────────────────────────────
+const AuthScreen = ({ auth, initialMode = 'signup', onContinue, onBack }) => {
+  const [mode, setMode] = React.useState(initialMode);
+  const [email, setEmail] = React.useState('');
+  const [pw, setPw] = React.useState('');
+  const [show, setShow] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  const strength = scorePassword(pw);
+  const strengthLabel = ['', 'Weak', 'Fair', 'Good', 'Strong'][strength];
+
+  const submit = async () => {
+    setSubmitting(true);
+    const fn = mode === 'signup' ? auth.signUp : auth.signIn;
+    const ok = await fn({ email, password: pw });
+    setSubmitting(false);
+    if (ok) onContinue();
+  };
+
+  const ctaDisabled = !email || !pw || submitting;
+
+  return (
+    <Screen padTop={64} padBottom={32} style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ padding: '0 24px' }}>
+        <button onClick={onBack} className="press" style={{
+          width: 40, height: 40, borderRadius: 9999, background: 'var(--surface-1)',
+          border: '1px solid var(--hairline)', color: 'var(--text-1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+          marginBottom: 32,
+        }}><Icon name="arrow-left" size={18} /></button>
+
+        <h1 style={{ fontSize: 30, lineHeight: 1.1, fontWeight: 600, letterSpacing: -0.8, margin: 0, marginBottom: 12 }}>
+          {mode === 'signup' ? 'Create your account' : 'Welcome back'}
+        </h1>
+        <p style={{ fontSize: 14, lineHeight: 1.5, color: 'var(--text-2)', margin: 0, marginBottom: 28 }}>
+          {mode === 'signup'
+            ? "We'll sync this account to your glasses so your programs follow you everywhere."
+            : 'Sign in to pick up where you left off.'}
+        </p>
+
+        <Field
+          label="Email"
+          icon="mail"
+          type="email"
+          value={email}
+          onChange={setEmail}
+          placeholder="you@example.com"
+        />
+
+        <Field
+          label="Password"
+          type={show ? 'text' : 'password'}
+          value={pw}
+          onChange={setPw}
+          placeholder="At least 8 characters"
+          trailing={
+            <button onClick={() => setShow(!show)} style={{
+              background: 'transparent', border: 'none', color: 'var(--text-3)',
+              cursor: 'pointer', display: 'flex', alignItems: 'center',
+            }}><Icon name={show ? 'eye-off' : 'eye'} size={18} stroke="var(--text-3)" /></button>
+          }
+        />
+
+        {mode === 'signup' && pw && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, margin: '-4px 4px 16px' }}>
+            <div style={{ display: 'flex', gap: 3, flex: 1 }}>
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} style={{
+                  flex: 1, height: 3, borderRadius: 2,
+                  background: i <= strength ? 'var(--accent)' : 'var(--overlay-3)',
+                }} />
+              ))}
+            </div>
+            <span style={{ fontSize: 11, color: 'var(--text-3)', minWidth: 40, textAlign: 'right' }}>
+              {strengthLabel}
+            </span>
+          </div>
+        )}
+
+        {auth.error && (
+          <div style={{
+            fontSize: 13, color: '#FF8B7C', marginBottom: 12, padding: '0 4px',
+          }}>{auth.error}</div>
+        )}
+
+        <Button onClick={submit} iconRight="arrow-right" disabled={ctaDisabled}>
+          {submitting
+            ? (mode === 'signup' ? 'Creating account…' : 'Signing in…')
+            : (mode === 'signup' ? 'Create account' : 'Sign in')}
+        </Button>
+
+        <button
+          onClick={() => setMode(mode === 'signup' ? 'login' : 'signup')}
+          className="press"
+          style={{
+            width: '100%', background: 'transparent', border: 'none', color: 'var(--text-2)',
+            fontSize: 13, padding: 16, marginTop: 8, cursor: 'pointer', fontFamily: 'var(--font-sans)',
+          }}
+        >
+          {mode === 'signup' ? 'Already have an account? Sign in' : 'New here? Create an account'}
+        </button>
+      </div>
+
+      <div style={{ flex: 1 }} />
+
+      <div style={{ padding: '0 24px', textAlign: 'center' }}>
+        <p style={{ fontSize: 11, color: 'var(--text-3)', lineHeight: 1.5, margin: 0 }}>
+          By continuing you agree to our Terms and Privacy Policy.
+        </p>
+      </div>
+    </Screen>
+  );
+};
+
+Object.assign(window, { Screen, SplashScreen, AuthScreen });

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -186,4 +186,114 @@ const AuthScreen = ({ auth, initialMode = 'signup', onContinue, onBack }) => {
   );
 };
 
-Object.assign(window, { Screen, SplashScreen, AuthScreen });
+// ─────────────────────────────────────────────────────────────
+// 3. Name — "what should we call you?"
+// ─────────────────────────────────────────────────────────────
+const NameScreen = ({ auth, onContinue, onBack }) => {
+  const [name, setName] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+
+  const submit = async () => {
+    if (!name.trim()) return;
+    setSubmitting(true);
+    const ok = await auth.setName(name.trim());
+    setSubmitting(false);
+    if (ok) onContinue();
+  };
+
+  return (
+    <Screen padTop={64} padBottom={32} style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ padding: '0 24px', marginBottom: 32 }}>
+        <button onClick={onBack} className="press" style={{
+          width: 40, height: 40, borderRadius: 9999, background: 'var(--surface-1)',
+          border: '1px solid var(--hairline)', color: 'var(--text-1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+        }}><Icon name="arrow-left" size={18} /></button>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 24px' }}>
+        <div className="fade-up">
+          <h1 style={{
+            fontSize: 30, lineHeight: 1.15, fontWeight: 600, letterSpacing: -0.7,
+            margin: 0, marginBottom: 10,
+          }}>What should we call you?</h1>
+          <p style={{ fontSize: 14, color: 'var(--text-2)', margin: 0, marginBottom: 32 }}>
+            Just a first name is fine — we'll use it on the glasses too.
+          </p>
+
+          <label style={{
+            display: 'block', fontSize: 11, color: 'var(--text-3)', marginBottom: 8,
+            letterSpacing: 0.4, textTransform: 'uppercase', fontWeight: 600,
+          }}>First name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+            placeholder="Alex"
+            style={{
+              width: '100%', height: 60, padding: '0 18px', borderRadius: 16,
+              background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+              color: 'var(--text-1)', fontSize: 18, fontFamily: 'var(--font-sans)', fontWeight: 500,
+              outline: 'none',
+            }}
+          />
+
+          <Card padding={16} style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{
+              width: 36, height: 36, borderRadius: 10, background: 'var(--accent-soft)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <Icon name="bolt" size={18} stroke="var(--accent)" />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 600 }}>Quick setup</div>
+              <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 2 }}>
+                Next, we'll pair your glasses. Takes about 30 seconds.
+              </div>
+            </div>
+          </Card>
+        </div>
+      </div>
+
+      <div style={{ padding: '24px 24px 0' }}>
+        <Button onClick={submit} iconRight="arrow-right" disabled={!name.trim() || submitting}>
+          {submitting ? 'Saving…' : 'Continue'}
+        </Button>
+      </div>
+    </Screen>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────
+// 4. Done — placeholder so the flow has somewhere to land. Real
+//    next step is glasses pairing, owned by a different ticket.
+// ─────────────────────────────────────────────────────────────
+const DoneScreen = ({ auth, onRestart }) => (
+  <Screen padTop={0} padBottom={0} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center', padding: '0 32px',
+      textAlign: 'center',
+    }}>
+      <div style={{
+        width: 88, height: 88, borderRadius: '50%',
+        background: 'var(--accent)', display: 'flex',
+        alignItems: 'center', justifyContent: 'center', marginBottom: 28,
+        boxShadow: '0 0 60px rgba(197,242,62,0.4)',
+      }}>
+        <Icon name="check" size={44} stroke="var(--on-accent)" strokeWidth={2.5} />
+      </div>
+      <h1 style={{ fontSize: 30, fontWeight: 600, letterSpacing: -0.7, margin: 0, marginBottom: 12 }}>
+        You're in{auth.user && auth.user.name ? `, ${auth.user.name}` : ''}.
+      </h1>
+      <p style={{ fontSize: 14, color: 'var(--text-2)', margin: 0, maxWidth: 280 }}>
+        Pairing your glasses is the next step — we'll wire that up in a follow-up.
+      </p>
+    </div>
+    <div style={{ padding: '0 24px 40px' }}>
+      <Button variant="ghost" onClick={onRestart}>Restart flow</Button>
+    </div>
+  </Screen>
+);
+
+Object.assign(window, { Screen, SplashScreen, AuthScreen, NameScreen, DoneScreen });

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -1,0 +1,73 @@
+// Signup flow screens: Splash → Auth → Name.
+//
+// Each screen is self-contained and takes onContinue/onBack callbacks.
+// State (email, password, name) lives in the screen itself; submission
+// is delegated to the auth hook passed in from app.jsx.
+
+// ─────────────────────────────────────────────────────────────
+// Screen wrapper — gives every screen the safe area + bg.
+// ─────────────────────────────────────────────────────────────
+const Screen = ({ children, padTop = 60, padBottom = 40, style = {} }) => (
+  <div className="no-scrollbar fade-up" style={{
+    width: '100%', height: '100%', background: 'var(--bg)',
+    paddingTop: padTop, paddingBottom: padBottom,
+    overflowY: 'auto', position: 'relative',
+    fontFamily: 'var(--font-sans)', color: 'var(--text-1)',
+    ...style,
+  }}>{children}</div>
+);
+
+// ─────────────────────────────────────────────────────────────
+// 1. Splash — welcome with the glasses visor graphic.
+// ─────────────────────────────────────────────────────────────
+const SplashScreen = ({ onSignUp, onSignIn }) => (
+  <Screen padTop={0} padBottom={0} style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      justifyContent: 'center', alignItems: 'center', position: 'relative',
+      background: 'radial-gradient(120% 80% at 50% 30%, rgba(197,242,62,0.18), transparent 60%)',
+      paddingTop: 80,
+    }}>
+      {/* Glasses visor — pure CSS */}
+      <div style={{ width: 220, height: 110, position: 'relative', marginBottom: 56 }}>
+        <div style={{
+          position: 'absolute', inset: 0, borderRadius: '50%',
+          border: '1.5px solid var(--accent)',
+          boxShadow: '0 0 60px rgba(197,242,62,0.4), inset 0 0 30px rgba(197,242,62,0.15)',
+          background: 'linear-gradient(180deg, rgba(197,242,62,0.08), transparent 60%)',
+        }} />
+        <div style={{
+          position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)',
+          fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: 3,
+          color: 'rgba(197,242,62,0.7)',
+        }}>TRAIN.AR</div>
+      </div>
+
+      <div style={{ textAlign: 'center', padding: '0 32px' }}>
+        <h1 style={{
+          fontSize: 40, lineHeight: 1.05, fontWeight: 600, letterSpacing: -1.2,
+          margin: 0, marginBottom: 14,
+        }}>
+          Train heads-up.<br/>
+          <span style={{ color: 'var(--accent)' }}>Eyes on the bar.</span>
+        </h1>
+        <p style={{
+          fontSize: 15, lineHeight: 1.5, color: 'var(--text-2)', margin: 0,
+          maxWidth: 300, marginInline: 'auto',
+        }}>
+          Your program lives in your AR glasses. The phone is just for setup.
+        </p>
+      </div>
+    </div>
+
+    <div style={{ padding: '0 24px 40px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <Button onClick={onSignUp} iconRight="arrow-right">Get started</Button>
+      <button onClick={onSignIn} className="press" style={{
+        background: 'transparent', border: 'none', color: 'var(--text-2)',
+        fontSize: 14, padding: 12, cursor: 'pointer', fontFamily: 'var(--font-sans)',
+      }}>I already have an account</button>
+    </div>
+  </Screen>
+);
+
+Object.assign(window, { Screen, SplashScreen });

--- a/ios/tokens.css
+++ b/ios/tokens.css
@@ -1,0 +1,54 @@
+/* TrainAR design tokens — copied from the design handoff so the iOS app matches the prototype. */
+:root {
+  /* Surfaces */
+  --bg: #0A0A0A;
+  --surface-1: #141414;
+  --surface-2: #1C1C1C;
+  --surface-3: #242424;
+  --hairline: rgba(255,255,255,0.07);
+  --hairline-2: rgba(255,255,255,0.12);
+
+  /* Text */
+  --text-1: #F5F5F5;
+  --text-2: rgba(245,245,245,0.65);
+  --text-3: rgba(245,245,245,0.42);
+  --text-dim: rgba(245,245,245,0.28);
+
+  /* Accent — electric lime */
+  --accent: #C5F23E;
+  --accent-soft: rgba(197, 242, 62, 0.14);
+  --accent-glow: 0 0 32px rgba(197, 242, 62, 0.35);
+  --on-accent: #0A0A0A;
+
+  /* Subtle white-tint overlays */
+  --overlay-1: rgba(255,255,255,0.05);
+  --overlay-2: rgba(255,255,255,0.06);
+  --overlay-3: rgba(255,255,255,0.08);
+
+  /* iPhone surround color on the canvas */
+  --frame-bg: #0A0A0A;
+
+  /* Type */
+  --font-sans: 'Inter', -apple-system, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Radii */
+  --r-pill: 9999px;
+  --r-card: 20px;
+  --r-card-lg: 28px;
+  --r-chip: 12px;
+}
+
+* { box-sizing: border-box; -webkit-font-smoothing: antialiased; }
+
+.no-scrollbar::-webkit-scrollbar { display: none; }
+.no-scrollbar { scrollbar-width: none; }
+
+.press { transition: transform 120ms ease, opacity 120ms ease; }
+.press:active { transform: scale(0.97); opacity: 0.85; }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.fade-up { animation: fadeUp 380ms cubic-bezier(.2,.7,.2,1) both; }

--- a/ios/ui.jsx
+++ b/ios/ui.jsx
@@ -1,0 +1,87 @@
+// Shared UI primitives for the TrainAR iOS app.
+// Mirrors the design handoff but trimmed to just what the signup flow needs.
+
+const Icon = ({ name, size = 20, stroke = 'currentColor', strokeWidth = 1.75, style = {} }) => {
+  const common = {
+    width: size, height: size, viewBox: '0 0 24 24', fill: 'none',
+    stroke, strokeWidth, strokeLinecap: 'round', strokeLinejoin: 'round', style,
+  };
+  switch (name) {
+    case 'arrow-right': return <svg {...common}><path d="M5 12h14M13 5l7 7-7 7"/></svg>;
+    case 'arrow-left':  return <svg {...common}><path d="M19 12H5M11 5l-7 7 7 7"/></svg>;
+    case 'mail':        return <svg {...common}><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 7 9-7"/></svg>;
+    case 'eye':         return <svg {...common}><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/></svg>;
+    case 'eye-off':     return <svg {...common}><path d="M3 3l18 18M10.6 10.6a3 3 0 0 0 4.2 4.2"/><path d="M9.9 5.1A10.7 10.7 0 0 1 12 5c6 0 10 7 10 7a17.4 17.4 0 0 1-3.2 3.9M6.6 6.6A17.4 17.4 0 0 0 2 12s4 7 10 7c1.4 0 2.7-.3 3.9-.7"/></svg>;
+    case 'bolt':        return <svg {...common}><path d="M13 2L4 14h7l-1 8 9-12h-7l1-8z"/></svg>;
+    case 'check':       return <svg {...common}><path d="M5 12l5 5L20 7"/></svg>;
+    default: return null;
+  }
+};
+
+const Card = ({ children, style = {}, padding = 20, onClick }) => (
+  <div onClick={onClick} className={onClick ? 'press' : ''} style={{
+    background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+    borderRadius: 'var(--r-card)', padding,
+    cursor: onClick ? 'pointer' : 'default',
+    ...style,
+  }}>{children}</div>
+);
+
+const Button = ({ children, onClick, variant = 'primary', size = 'lg', iconRight, style = {}, disabled }) => {
+  const sizes = {
+    lg: { height: 56, padding: '0 24px', fontSize: 16 },
+    md: { height: 44, padding: '0 18px', fontSize: 14 },
+    sm: { height: 32, padding: '0 14px', fontSize: 13 },
+  }[size];
+  const variants = {
+    primary: { background: 'var(--accent)',   color: 'var(--on-accent)', border: 'none' },
+    ghost:   { background: 'transparent',     color: 'var(--text-1)',   border: '1px solid var(--hairline-2)' },
+    surface: { background: 'var(--surface-2)', color: 'var(--text-1)',   border: '1px solid var(--hairline)' },
+  }[variant];
+  return (
+    <button onClick={onClick} disabled={disabled} className="press" style={{
+      ...sizes, ...variants,
+      borderRadius: 9999,
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+      fontFamily: 'var(--font-sans)', fontWeight: 600,
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      opacity: disabled ? 0.5 : 1,
+      width: '100%',
+      ...style,
+    }}>
+      <span>{children}</span>
+      {iconRight && <Icon name={iconRight} size={size === 'sm' ? 16 : 18} />}
+    </button>
+  );
+};
+
+// Labelled input row, used by every form field in the signup flow.
+const Field = ({ label, icon, type = 'text', value, onChange, placeholder, trailing, autoFocus }) => (
+  <div style={{ marginBottom: 16 }}>
+    <label style={{
+      display: 'block', fontSize: 11, color: 'var(--text-3)',
+      marginBottom: 8, letterSpacing: 0.4, textTransform: 'uppercase', fontWeight: 600,
+    }}>{label}</label>
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      padding: '0 16px', height: 56, borderRadius: 16,
+      background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+    }}>
+      {icon && <Icon name={icon} size={18} stroke="var(--text-3)" />}
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        style={{
+          flex: 1, background: 'transparent', border: 'none', outline: 'none',
+          color: 'var(--text-1)', fontSize: 15, fontFamily: 'var(--font-sans)',
+        }}
+      />
+      {trailing}
+    </div>
+  </div>
+);
+
+Object.assign(window, { Icon, Card, Button, Field });


### PR DESCRIPTION
Closes #44, #45, #46, #47.

## What's in this
Just the UI for the iPhone signup flow, based on the TrainAR Prototype design handoff.

- `ios/index.html` — entry point, no build step (React + Babel via CDN)
- `ios/tokens.css` — dark + lime design tokens
- `ios/ui.jsx` — Icon, Button, Card, Field
- `ios/ios-frame.jsx` — iPhone device frame
- `ios/screens-signup.jsx` — Splash, Auth, Name, Done
- `ios/auth.js` — `useAuth()` stub with localStorage persistence
- `ios/app.jsx` — wires the state machine

Flow: splash -> auth (signup/signin toggle) -> name -> done.

## Backend swap later
Screens never call a backend directly — they only talk to `useAuth()`. When we have a real backend we replace the bodies of `signUp`, `signIn`, and `setName` in `auth.js` and the screens stay untouched.

## Test plan
- [x] Open `ios/index.html` in a browser, click through splash -> auth -> name -> done
- [x] JSX files parse cleanly via @babel/standalone
- [x] `scorePassword` smoke test returns expected scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)