### PR TITLE
Pair glasses screen (placeholder)

### DIFF
--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -1,6 +1,6 @@
 // App — wires the signup screens into the iPhone frame.
 //
-// Tiny state machine: 'splash' → 'auth' → 'name' → 'done'.
+// Tiny state machine: 'splash' → 'auth' → 'name' → 'pair' → 'done'.
 // `mode` decides whether the auth screen opens in signup or sign-in mode.
 
 const PROTOTYPE_W = 402;
@@ -35,15 +35,22 @@ function App() {
       <AuthScreen
         auth={auth}
         initialMode={mode}
-        onContinue={() => setScreen(mode === 'signup' ? 'name' : 'done')}
+        onContinue={() => setScreen(mode === 'signup' ? 'name' : 'pair')}
         onBack={() => setScreen('splash')}
       />
     ),
     name: (
       <NameScreen
         auth={auth}
-        onContinue={() => setScreen('done')}
+        onContinue={() => setScreen('pair')}
         onBack={() => setScreen('auth')}
+      />
+    ),
+    pair: (
+      <PairScreen
+        onContinue={() => setScreen('done')}
+        onSkip={() => setScreen('done')}
+        onBack={() => setScreen(auth.user && auth.user.name ? 'name' : 'auth')}
       />
     ),
     done: <DoneScreen auth={auth} onRestart={restart} />,

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -296,4 +296,132 @@ const DoneScreen = ({ auth, onRestart }) => (
   </Screen>
 );
 
-Object.assign(window, { Screen, SplashScreen, AuthScreen, NameScreen, DoneScreen });
+// ─────────────────────────────────────────────────────────────
+// 4. Pair glasses — placeholder.
+//
+// We don't actually talk to glasses yet. The whole screen is fake-timer
+// driven so the visual flow matches the design. When a real bluetooth/
+// pairing layer exists, swap the setTimeout calls for real callbacks.
+// ─────────────────────────────────────────────────────────────
+const PairScreen = ({ onContinue, onSkip, onBack }) => {
+  const [phase, setPhase] = React.useState('searching'); // searching → found → connected
+
+  // Pretend to scan for glasses, then "discover" one.
+  React.useEffect(() => {
+    const t = setTimeout(() => setPhase('found'), 1600);
+    return () => clearTimeout(t);
+  }, []);
+
+  const pair = () => {
+    setPhase('connected');
+    setTimeout(onContinue, 1100);
+  };
+
+  const connected = phase === 'connected';
+
+  return (
+    <Screen padTop={64} padBottom={32} style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ padding: '0 24px' }}>
+        <button onClick={onBack} className="press" style={{
+          width: 40, height: 40, borderRadius: 9999, background: 'var(--surface-1)',
+          border: '1px solid var(--hairline)', color: 'var(--text-1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+          marginBottom: 24,
+        }}><Icon name="arrow-left" size={18} /></button>
+
+        <h1 style={{
+          fontSize: 28, lineHeight: 1.15, fontWeight: 600, letterSpacing: -0.6,
+          margin: 0, marginBottom: 10,
+        }}>Pair your glasses</h1>
+        <p style={{ fontSize: 14, color: 'var(--text-2)', margin: 0, marginBottom: 32 }}>
+          Make sure your glasses are powered on and within 3 feet.
+        </p>
+      </div>
+
+      {/* Big concentric indicator. */}
+      <div style={{
+        flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        position: 'relative',
+      }}>
+        <div style={{
+          width: 240, height: 240, borderRadius: '50%',
+          border: '1px solid ' + (connected ? 'var(--accent)' : 'var(--hairline-2)'),
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          position: 'relative',
+          boxShadow: connected ? '0 0 80px rgba(197,242,62,0.5)' : 'none',
+          transition: 'all 600ms',
+        }}>
+          {phase === 'searching' && (
+            <div className="spin-ring" style={{
+              position: 'absolute', inset: -1, borderRadius: '50%',
+              border: '2px solid transparent', borderTopColor: 'var(--accent)',
+            }} />
+          )}
+          <div style={{
+            width: 130, height: 130, borderRadius: '50%',
+            background: connected ? 'var(--accent)' : 'var(--surface-1)',
+            border: '1px solid ' + (connected ? 'var(--accent)' : 'var(--hairline)'),
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            transition: 'all 400ms',
+          }}>
+            {connected
+              ? <Icon name="check"   size={56} stroke="var(--on-accent)" strokeWidth={2.5} />
+              : <Icon name="glasses" size={56} stroke="var(--text-1)"   strokeWidth={1.5} />}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: '0 24px 0', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {phase === 'searching' && (
+          <Card style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div className="pulse-dot" style={{
+              width: 8, height: 8, borderRadius: 4, background: 'var(--accent)',
+            }} />
+            <div style={{ fontSize: 14, color: 'var(--text-2)' }}>Searching for nearby glasses…</div>
+          </Card>
+        )}
+
+        {phase === 'found' && (
+          <Card>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+              <div style={{
+                width: 44, height: 44, borderRadius: 12, background: 'var(--surface-2)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                <Icon name="glasses" size={22} />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 15, fontWeight: 600 }}>TrainAR · M2</div>
+                <div style={{
+                  fontSize: 11, color: 'var(--text-3)', marginTop: 2,
+                  fontFamily: 'var(--font-mono)',
+                }}>SN · 8E40·B7C2 · -54 dBm</div>
+              </div>
+              <Button size="sm" onClick={pair} style={{ width: 'auto' }}>Pair</Button>
+            </div>
+          </Card>
+        )}
+
+        {connected && (
+          <Card style={{
+            background: 'var(--accent-soft)', border: '1px solid rgba(197,242,62,0.3)',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+              <Icon name="check" size={20} stroke="var(--accent)" strokeWidth={2.5} />
+              <div style={{ fontSize: 14, color: 'var(--accent)', fontWeight: 600 }}>
+                Paired — finishing setup…
+              </div>
+            </div>
+          </Card>
+        )}
+
+        <button onClick={onSkip} className="press" style={{
+          background: 'transparent', border: 'none', color: 'var(--text-2)',
+          fontSize: 13, padding: 12, cursor: 'pointer', fontFamily: 'var(--font-sans)',
+        }}>I'll do this later</button>
+      </div>
+    </Screen>
+  );
+};
+
+Object.assign(window, { Screen, SplashScreen, AuthScreen, NameScreen, PairScreen, DoneScreen });

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -287,7 +287,7 @@ const DoneScreen = ({ auth, onRestart }) => (
         You're in{auth.user && auth.user.name ? `, ${auth.user.name}` : ''}.
       </h1>
       <p style={{ fontSize: 14, color: 'var(--text-2)', margin: 0, maxWidth: 280 }}>
-        Pairing your glasses is the next step — we'll wire that up in a follow-up.
+        Setup's done. The home screen and the rest of the app come next.
       </p>
     </div>
     <div style={{ padding: '0 24px 40px' }}>

--- a/ios/tokens.css
+++ b/ios/tokens.css
@@ -52,3 +52,14 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 .fade-up { animation: fadeUp 380ms cubic-bezier(.2,.7,.2,1) both; }
+
+/* Pulsing dot used by the "searching for glasses" state. */
+@keyframes pulseDot {
+  0%, 100% { opacity: 1;   transform: scale(1); }
+  50%      { opacity: 0.5; transform: scale(0.85); }
+}
+.pulse-dot { animation: pulseDot 1.6s ease-in-out infinite; }
+
+/* Spinner ring around the pair indicator while it's searching. */
+@keyframes spinRing { to { transform: rotate(360deg); } }
+.spin-ring { animation: spinRing 1.4s linear infinite; }

--- a/ios/ui.jsx
+++ b/ios/ui.jsx
@@ -14,6 +14,7 @@ const Icon = ({ name, size = 20, stroke = 'currentColor', strokeWidth = 1.75, st
     case 'eye-off':     return <svg {...common}><path d="M3 3l18 18M10.6 10.6a3 3 0 0 0 4.2 4.2"/><path d="M9.9 5.1A10.7 10.7 0 0 1 12 5c6 0 10 7 10 7a17.4 17.4 0 0 1-3.2 3.9M6.6 6.6A17.4 17.4 0 0 0 2 12s4 7 10 7c1.4 0 2.7-.3 3.9-.7"/></svg>;
     case 'bolt':        return <svg {...common}><path d="M13 2L4 14h7l-1 8 9-12h-7l1-8z"/></svg>;
     case 'check':       return <svg {...common}><path d="M5 12l5 5L20 7"/></svg>;
+    case 'glasses':     return <svg {...common}><circle cx="6.5" cy="14" r="3.5"/><circle cx="17.5" cy="14" r="3.5"/><path d="M10 14c.5-1 1.5-1 2 0M3 9l3.5-2M21 9l-3.5-2"/></svg>;
     default: return null;
   }
 };


### PR DESCRIPTION
Closes #49.

Adds the 4th signup screen so the app matches the design grid (splash → sign in → name → pair).

## What's in this
- `ios/screens-signup.jsx` — new `PairScreen` with searching → found → connected states
- `ios/app.jsx` — wires it in: name continues to pair, signin skips name and goes straight to pair, pair continues (or skips) to done
- `ios/ui.jsx` — added the glasses icon
- `ios/tokens.css` — added pulse-dot + spin-ring keyframes

## What's NOT in this
The actual glasses pairing — there's no real bluetooth/device discovery. State transitions run on `setTimeout` so the visual flow plays out. When we know the real pairing protocol, swap the timeouts for real callbacks (same swap-the-stub pattern as `auth.js`).

## Test plan
- [x] Open `ios/index.html`, click through splash → auth → name → pair → done
- [x] Verified in preview: pair screen renders title, "TrainAR · M2" device card with Pair button, and "I'll do this later" skip
- [x] Clicking Pair triggers the connected state and lands on Done
- [x] No console errors (just expected in-browser Babel warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)