### PR TITLE
Add a program flow (UI for camera/upload/parse/review)

### DIFF
--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -1,6 +1,9 @@
-// App — wires the signup screens into the iPhone frame.
+// App — wires the signup + add-program screens into the iPhone frame.
 //
-// Tiny state machine: 'splash' → 'auth' → 'name' → 'pair' → 'done'.
+// Tiny state machine:
+//   splash → auth → name → pair → done
+//   done → add → camera → parsing → review → done
+//
 // `mode` decides whether the auth screen opens in signup or sign-in mode.
 
 const PROTOTYPE_W = 402;
@@ -53,7 +56,36 @@ function App() {
         onBack={() => setScreen(auth.user && auth.user.name ? 'name' : 'auth')}
       />
     ),
-    done: <DoneScreen auth={auth} onRestart={restart} />,
+    done: (
+      <DoneScreen
+        auth={auth}
+        onAddProgram={() => setScreen('add')}
+        onRestart={restart}
+      />
+    ),
+
+    // ── Add a program ───────────────────────────────────────────
+    add: (
+      <AddProgramScreen
+        onCamera={() => setScreen('camera')}
+        onUpload={() => setScreen('parsing')}
+        onLibrary={() => setScreen('parsing')}
+        onClose={() => setScreen('done')}
+      />
+    ),
+    camera: (
+      <CameraScreen
+        onCapture={() => setScreen('parsing')}
+        onClose={() => setScreen('add')}
+      />
+    ),
+    parsing: <ParsingScreen onDone={() => setScreen('review')} />,
+    review: (
+      <ReviewScreen
+        onConfirm={() => setScreen('done')}
+        onClose={() => setScreen('done')}
+      />
+    ),
   };
 
   return (

--- a/ios/data.js
+++ b/ios/data.js
@@ -1,0 +1,44 @@
+// Placeholder parsed-program payload.
+//
+// The review screen reads from window.PARSED_PROGRAM. Right now this is hard-
+// coded sample data — when the backend ships, it can populate this object (or
+// pass it as a prop) with the actual OCR/parser output.
+//
+// Shape is intentionally simple: title, author, totals, weekly schedule,
+// flagged-for-review entries.
+
+window.PARSED_PROGRAM = {
+  title: 'Powerbuilding 5×',
+  author: 'J. Nippard',
+  description: 'We extracted 10 weeks · 5 days/week · 47 unique exercises. Review below before saving.',
+  stats: [
+    { label: 'Weeks',   value: '10' },
+    { label: 'Days/wk', value: '5'  },
+    { label: 'Lifts',   value: '47' },
+  ],
+  schedule: [
+    { day: 'Mon', name: 'Full Body 1', tag: 'Squat focus' },
+    { day: 'Tue', name: 'Full Body 2', tag: 'Bench focus' },
+    { day: 'Wed', name: 'Full Body 3', tag: 'Pull focus' },
+    { day: 'Thu', name: 'Rest',        tag: 'Recovery' },
+    { day: 'Fri', name: 'Full Body 4', tag: 'Deadlift focus' },
+    { day: 'Sat', name: 'Full Body 5', tag: 'Press / arms' },
+    { day: 'Sun', name: 'Rest',        tag: 'Recovery' },
+  ],
+  flagged: [
+    { exercise: 'Pin Good Morning',     issue: "Couldn't read pin height — defaulted to \"high\"." },
+    { exercise: 'AMRAP test (week 10)', issue: 'Two options found — A and B. Pick one before week 10.' },
+  ],
+};
+
+// Lines shown on the camera "paper" placeholder + the parsing screen's preview
+// thumb. Mirrors what a typical strength program sheet looks like so the
+// silhouette feels real.
+window.PROGRAM_SAMPLE_LINES = [
+  'Back Squat (Top Single) · 1×1 @ 87.5%',
+  'Back Squat · 5×3 @ 77.5%',
+  'OHP · 3×8',
+  'Pin Good Morning · 2×8-10',
+  'Chest-Sup. Row · 4×8-10',
+  'Hanging Leg Raise · 3×10',
+];

--- a/ios/index.html
+++ b/ios/index.html
@@ -24,10 +24,14 @@
   <!-- Auth stub — kept plain JS so it's easy to swap with a real backend later -->
   <script src="auth.js"></script>
 
+  <!-- Sample placeholder data — backend will replace this -->
+  <script src="data.js"></script>
+
   <!-- UI primitives, then the iOS frame, then the screens, then the app -->
   <script type="text/babel" src="ui.jsx"></script>
   <script type="text/babel" src="ios-frame.jsx"></script>
   <script type="text/babel" src="screens-signup.jsx"></script>
+  <script type="text/babel" src="screens-add-program.jsx"></script>
   <script type="text/babel" src="app.jsx"></script>
 </body>
 </html>

--- a/ios/screens-add-program.jsx
+++ b/ios/screens-add-program.jsx
@@ -1,0 +1,115 @@
+// Add-program flow screens: Entry → Camera → Parsing → Review.
+//
+// Frontend only. The camera screen draws chrome over a placeholder where the
+// camera feed will eventually render; parsing runs on a fake timer; review
+// reads from window.PARSED_PROGRAM. Backend swaps these in later.
+
+// Reuses the Screen wrapper defined in screens-signup.jsx.
+
+// ─────────────────────────────────────────────────────────────
+// 1. Entry — pick a source.
+// ─────────────────────────────────────────────────────────────
+const AddProgramScreen = ({ onCamera, onUpload, onLibrary, onClose }) => (
+  <Screen padTop={64} padBottom={32}>
+    <div style={{
+      padding: '0 20px 16px', display: 'flex',
+      alignItems: 'center', justifyContent: 'space-between',
+    }}>
+      <div>
+        <h1 style={{ fontSize: 26, fontWeight: 600, letterSpacing: -0.5, margin: 0 }}>
+          Add a program
+        </h1>
+        <p style={{ fontSize: 13, color: 'var(--text-2)', margin: 0, marginTop: 4 }}>
+          Drop in any program. We'll parse and structure it.
+        </p>
+      </div>
+      <button onClick={onClose} className="press" style={{
+        width: 36, height: 36, borderRadius: 9999, background: 'var(--surface-1)',
+        border: '1px solid var(--hairline)', color: 'var(--text-1)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+      }}><Icon name="x" size={16} /></button>
+    </div>
+
+    <div style={{
+      padding: '12px 20px', display: 'flex',
+      flexDirection: 'column', gap: 10,
+    }}>
+      {/* Hero — Take a photo */}
+      <button onClick={onCamera} className="press" style={{
+        position: 'relative', overflow: 'hidden',
+        padding: 22, borderRadius: 'var(--r-card-lg)',
+        background: 'var(--hero-bg)',
+        border: '1px solid var(--hero-border)',
+        color: 'var(--text-1)', textAlign: 'left', cursor: 'pointer',
+        fontFamily: 'var(--font-sans)',
+      }}>
+        <div style={{
+          position: 'absolute', top: -30, right: -30, width: 120, height: 120,
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(197,242,62,0.2), transparent 60%)',
+        }} />
+        <div style={{
+          width: 48, height: 48, borderRadius: 14, background: 'var(--accent)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16,
+          position: 'relative',
+        }}>
+          <Icon name="camera" size={22} stroke="var(--on-accent)" strokeWidth={2} />
+        </div>
+        <div style={{ fontSize: 17, fontWeight: 600, marginBottom: 4, position: 'relative' }}>
+          Take a photo
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.4, position: 'relative' }}>
+          Snap your spreadsheet, whiteboard, or coach's notebook.
+        </div>
+      </button>
+
+      {/* Upload a file */}
+      <button onClick={onUpload} className="press" style={{
+        padding: 22, borderRadius: 'var(--r-card-lg)',
+        background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+        color: 'var(--text-1)', textAlign: 'left', cursor: 'pointer',
+        fontFamily: 'var(--font-sans)',
+      }}>
+        <div style={{
+          width: 48, height: 48, borderRadius: 14, background: 'var(--surface-2)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16,
+          border: '1px solid var(--hairline)',
+        }}>
+          <Icon name="upload" size={20} />
+        </div>
+        <div style={{ fontSize: 17, fontWeight: 600, marginBottom: 4 }}>Upload a file</div>
+        <div style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.4 }}>
+          PDF, image, spreadsheet, or plain text from your library.
+        </div>
+      </button>
+
+      {/* Browse community */}
+      <button onClick={onLibrary} className="press" style={{
+        padding: 18, borderRadius: 'var(--r-card)',
+        background: 'transparent', border: '1px dashed var(--hairline-2)',
+        color: 'var(--text-2)', textAlign: 'left', cursor: 'pointer',
+        fontFamily: 'var(--font-sans)',
+        display: 'flex', alignItems: 'center', gap: 14,
+      }}>
+        <div style={{
+          width: 36, height: 36, borderRadius: 10, background: 'transparent',
+          border: '1px solid var(--hairline)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Icon name="sparkle" size={18} stroke="var(--text-2)" />
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-1)' }}>
+            Browse community programs
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 2 }}>
+            5/3/1, nSuns, PPL, Starting Strength…
+          </div>
+        </div>
+        <Icon name="chevron-right" size={16} stroke="var(--text-3)" />
+      </button>
+    </div>
+  </Screen>
+);
+
+Object.assign(window, { AddProgramScreen });

--- a/ios/screens-add-program.jsx
+++ b/ios/screens-add-program.jsx
@@ -348,4 +348,162 @@ const ParsingScreen = ({ onDone }) => {
   );
 };
 
-Object.assign(window, { AddProgramScreen, CameraScreen, ParsingScreen });
+// ─────────────────────────────────────────────────────────────
+// 4. Review — confirm parsed program before saving.
+//
+// Reads from window.PARSED_PROGRAM. Backend can either mutate that
+// object before we render, or we can lift it to a prop later.
+// ─────────────────────────────────────────────────────────────
+const ReviewScreen = ({ program, onConfirm, onClose }) => {
+  const p = program || window.PARSED_PROGRAM || {};
+  const stats    = p.stats    || [];
+  const schedule = p.schedule || [];
+  const flagged  = p.flagged  || [];
+
+  return (
+    <Screen padTop={64} padBottom={130}>
+      <div style={{
+        padding: '0 20px 16px', display: 'flex',
+        alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <button onClick={onClose} className="press" style={{
+          width: 36, height: 36, borderRadius: 9999,
+          background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+          color: 'var(--text-1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+        }}><Icon name="arrow-left" size={16} /></button>
+        <Pill accent>● Parsed</Pill>
+      </div>
+
+      <div style={{ padding: '0 20px 14px' }}>
+        <div style={{
+          fontSize: 12, color: 'var(--text-3)', marginBottom: 4,
+          fontFamily: 'var(--font-mono)', letterSpacing: 0.5,
+        }}>{p.author ? `REVIEW · BY ${p.author.toUpperCase()}` : 'REVIEW'}</div>
+        <h1 style={{ fontSize: 30, fontWeight: 600, letterSpacing: -0.6, margin: 0, marginBottom: 8 }}>
+          {p.title || 'Untitled program'}
+        </h1>
+        {p.description && (
+          <p style={{ fontSize: 13, color: 'var(--text-2)', margin: 0, lineHeight: 1.5 }}>
+            {p.description}
+          </p>
+        )}
+      </div>
+
+      {/* Stats row. */}
+      {stats.length > 0 && (
+        <div style={{ padding: '0 20px 18px' }}>
+          <div style={{
+            display: 'grid', gridTemplateColumns: `repeat(${stats.length}, 1fr)`, gap: 1,
+            background: 'var(--hairline)', border: '1px solid var(--hairline)',
+            borderRadius: 16, overflow: 'hidden',
+          }}>
+            {stats.map((s) => (
+              <div key={s.label} style={{
+                background: 'var(--surface-1)', padding: '14px 12px', textAlign: 'center',
+              }}>
+                <div className="mono" style={{
+                  fontSize: 22, fontWeight: 600, color: 'var(--accent)',
+                }}>{s.value}</div>
+                <div style={{
+                  fontSize: 10, color: 'var(--text-3)', marginTop: 2,
+                  textTransform: 'uppercase', letterSpacing: 0.5,
+                }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Weekly schedule. */}
+      {schedule.length > 0 && (
+        <div style={{ padding: '0 20px 18px' }}>
+          <div style={{
+            fontSize: 13, fontWeight: 600, color: 'var(--text-2)',
+            marginBottom: 10, padding: '0 4px',
+          }}>Weekly schedule</div>
+          <Card padding={4}>
+            {schedule.map((d, i) => (
+              <div key={i} style={{
+                display: 'flex', alignItems: 'center', gap: 12,
+                padding: '12px 14px',
+                borderBottom: i < schedule.length - 1 ? '1px solid var(--hairline)' : 'none',
+              }}>
+                <div className="mono" style={{
+                  width: 32, fontSize: 11, color: 'var(--text-3)',
+                  textTransform: 'uppercase',
+                }}>{d.day}</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{
+                    fontSize: 13, fontWeight: 500,
+                    color: d.name === 'Rest' ? 'var(--text-3)' : 'var(--text-1)',
+                  }}>{d.name}</div>
+                  <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 1 }}>{d.tag}</div>
+                </div>
+                {d.name !== 'Rest' && (
+                  <div style={{
+                    width: 6, height: 6, borderRadius: 3, background: 'var(--accent)',
+                  }} />
+                )}
+              </div>
+            ))}
+          </Card>
+        </div>
+      )}
+
+      {/* Flagged for review. */}
+      {flagged.length > 0 && (
+        <div style={{ padding: '0 20px 24px' }}>
+          <div style={{
+            fontSize: 13, fontWeight: 600, color: 'var(--text-2)',
+            marginBottom: 10, padding: '0 4px',
+            display: 'flex', alignItems: 'center', gap: 6,
+          }}>
+            Flagged for review{' '}
+            <Pill style={{
+              background: 'rgba(255,196,98,0.1)', color: 'var(--warn)',
+              borderColor: 'rgba(255,196,98,0.25)',
+            }}>{flagged.length}</Pill>
+          </div>
+          <Card padding={0}>
+            {flagged.map((f, i) => (
+              <div key={i} style={{
+                padding: '14px 16px',
+                borderBottom: i < flagged.length - 1 ? '1px solid var(--hairline)' : 'none',
+                display: 'flex', alignItems: 'flex-start', gap: 12,
+              }}>
+                <div style={{
+                  width: 24, height: 24, borderRadius: 7,
+                  background: 'rgba(255,196,98,0.12)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  flexShrink: 0,
+                }}>
+                  <span style={{ fontSize: 11, color: 'var(--warn)', fontWeight: 700 }}>!</span>
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 2 }}>{f.exercise}</div>
+                  <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.4 }}>{f.issue}</div>
+                </div>
+                <Icon name="chevron-right" size={16} stroke="var(--text-3)" />
+              </div>
+            ))}
+          </Card>
+        </div>
+      )}
+
+      {/* Sticky-ish bottom CTA. */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0,
+        padding: '16px 20px 24px',
+        background: 'linear-gradient(180deg, transparent, var(--bg) 30%)',
+      }}>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Button variant="ghost" onClick={onClose}   style={{ flex: 1 }}>Discard</Button>
+          <Button                onClick={onConfirm} iconRight="check" style={{ flex: 2 }}>Save program</Button>
+        </div>
+      </div>
+    </Screen>
+  );
+};
+
+Object.assign(window, { AddProgramScreen, CameraScreen, ParsingScreen, ReviewScreen });

--- a/ios/screens-add-program.jsx
+++ b/ios/screens-add-program.jsx
@@ -112,4 +112,131 @@ const AddProgramScreen = ({ onCamera, onUpload, onLibrary, onClose }) => (
   </Screen>
 );
 
-Object.assign(window, { AddProgramScreen });
+// ─────────────────────────────────────────────────────────────
+// 2. Camera — UI over a real camera view.
+//
+// The big rotated "paper" rectangle in the middle is a placeholder for
+// the camera feed. When the backend wires up a real camera, swap the
+// paper div for a <video> element bound to getUserMedia (or whatever
+// they end up using). The rest of the chrome — close, flash, reticles,
+// hint pill, capture button — stays the same.
+// ─────────────────────────────────────────────────────────────
+const CameraScreen = ({ onCapture, onClose }) => {
+  const lines = window.PROGRAM_SAMPLE_LINES || [];
+  return (
+    <Screen padTop={0} padBottom={0} style={{
+      display: 'flex', flexDirection: 'column', background: '#000',
+    }}>
+      {/* Viewfinder area — the placeholder lives in here. */}
+      <div style={{
+        flex: 1, position: 'relative',
+        background: 'linear-gradient(180deg, #1a1a1a, #0a0a0a)',
+        overflow: 'hidden',
+      }}>
+        {/* Placeholder for the camera feed — fake "paper" page. */}
+        <div style={{
+          position: 'absolute', top: 80, left: 30, right: 30, bottom: 120,
+          background: '#f4f1ea', borderRadius: 4, padding: 16,
+          transform: 'rotate(-2.4deg)',
+          boxShadow: '0 30px 60px rgba(0,0,0,0.6)',
+          fontFamily: 'var(--font-mono)', fontSize: 9, color: '#3a3a3a',
+          lineHeight: 1.6, overflow: 'hidden',
+        }}>
+          <div style={{ fontWeight: 700, fontSize: 11, marginBottom: 6 }}>
+            WEEK 3 — FULL BODY 1
+          </div>
+          <div style={{ borderBottom: '1px solid #ccc', marginBottom: 6 }} />
+          {lines.map((l, i) => <div key={i}>{l}</div>)}
+        </div>
+
+        {/* Corner reticles framing the program region. */}
+        {[[40, 40], [40, 'auto', 'auto', 40], ['auto', 40, 40, 'auto'], ['auto', 'auto', 40, 40]].map((c, i) => (
+          <div key={i} style={{
+            position: 'absolute',
+            top: c[0], right: c[1], bottom: c[2], left: c[3],
+            width: 28, height: 28,
+            borderTop:    c[0] !== 'auto' ? '2px solid var(--accent)' : 'none',
+            borderBottom: c[2] !== 'auto' ? '2px solid var(--accent)' : 'none',
+            borderLeft:   c[3] !== 'auto' ? '2px solid var(--accent)' : 'none',
+            borderRight:  c[1] !== 'auto' ? '2px solid var(--accent)' : 'none',
+            borderTopLeftRadius:     c[0] !== 'auto' && c[3] !== 'auto' ? 8 : 0,
+            borderTopRightRadius:    c[0] !== 'auto' && c[1] !== 'auto' ? 8 : 0,
+            borderBottomLeftRadius:  c[2] !== 'auto' && c[3] !== 'auto' ? 8 : 0,
+            borderBottomRightRadius: c[2] !== 'auto' && c[1] !== 'auto' ? 8 : 0,
+          }} />
+        ))}
+
+        {/* AI hint pill. */}
+        <div style={{
+          position: 'absolute', top: 70, left: 0, right: 0,
+          display: 'flex', justifyContent: 'center',
+        }}>
+          <div style={{
+            display: 'inline-flex', alignItems: 'center', gap: 8,
+            padding: '8px 14px', borderRadius: 9999,
+            background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(20px)',
+            WebkitBackdropFilter: 'blur(20px)',
+            border: '1px solid rgba(197,242,62,0.3)',
+            color: 'var(--accent)', fontSize: 12, fontWeight: 600,
+          }}>
+            <Icon name="sparkle" size={14} stroke="var(--accent)" />
+            Program detected — hold steady
+          </div>
+        </div>
+
+        {/* Top close + flash. */}
+        <button onClick={onClose} className="press" style={{
+          position: 'absolute', top: 60, left: 20,
+          width: 40, height: 40, borderRadius: 9999,
+          background: 'rgba(0,0,0,0.6)',
+          backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)',
+          border: '1px solid rgba(255,255,255,0.15)', color: 'var(--text-1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+        }}><Icon name="x" size={18} /></button>
+        <button className="press" style={{
+          position: 'absolute', top: 60, right: 20,
+          width: 40, height: 40, borderRadius: 9999,
+          background: 'rgba(0,0,0,0.6)',
+          backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)',
+          border: '1px solid rgba(255,255,255,0.15)', color: 'var(--text-1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+        }}><Icon name="flash" size={18} /></button>
+      </div>
+
+      {/* Bottom controls — gallery, capture, flip. */}
+      <div style={{
+        padding: '24px 20px 36px', background: '#000',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-around',
+      }}>
+        <button className="press" style={{
+          width: 52, height: 52, borderRadius: 14,
+          background: 'var(--surface-2)', border: '1px solid var(--hairline)',
+          color: 'var(--text-1)', cursor: 'pointer',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}><Icon name="image" size={20} /></button>
+
+        <button onClick={onCapture} className="press" style={{
+          width: 78, height: 78, borderRadius: '50%',
+          background: 'transparent',
+          border: '3px solid rgba(255,255,255,0.3)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          cursor: 'pointer', padding: 4,
+        }}>
+          <div style={{
+            width: '100%', height: '100%', borderRadius: '50%',
+            background: 'var(--accent)',
+          }} />
+        </button>
+
+        <button className="press" style={{
+          width: 52, height: 52, borderRadius: 14,
+          background: 'var(--surface-2)', border: '1px solid var(--hairline)',
+          color: 'var(--text-1)', cursor: 'pointer',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}><Icon name="rotate" size={20} /></button>
+      </div>
+    </Screen>
+  );
+};
+
+Object.assign(window, { AddProgramScreen, CameraScreen });

--- a/ios/screens-add-program.jsx
+++ b/ios/screens-add-program.jsx
@@ -239,4 +239,113 @@ const CameraScreen = ({ onCapture, onClose }) => {
   );
 };
 
-Object.assign(window, { AddProgramScreen, CameraScreen });
+// ─────────────────────────────────────────────────────────────
+// 3. Parsing — AI phases animation.
+//
+// Walks through the phases on a fake timer and then advances. When the
+// real parser ships, replace the setTimeout chain with something that
+// reflects actual progress events from the backend.
+// ─────────────────────────────────────────────────────────────
+const ParsingScreen = ({ onDone }) => {
+  const phases = [
+    'Reading the image',
+    'Identifying exercises',
+    'Parsing sets, reps, percentages',
+    'Structuring the schedule',
+  ];
+  const [phase, setPhase] = React.useState(0);
+
+  React.useEffect(() => {
+    if (phase < phases.length - 1) {
+      const t = setTimeout(() => setPhase(phase + 1), 850);
+      return () => clearTimeout(t);
+    }
+    const t = setTimeout(onDone, 900);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  const lines = window.PROGRAM_SAMPLE_LINES || [];
+
+  return (
+    <Screen padTop={64} padBottom={40} style={{ display: 'flex', flexDirection: 'column' }}>
+      {/* Tiny preview thumb of the captured page with a sweeping scan line. */}
+      <div style={{ padding: '0 20px 24px', display: 'flex', justifyContent: 'center' }}>
+        <div style={{
+          width: 160, height: 200, borderRadius: 16,
+          background: '#f4f1ea', position: 'relative', overflow: 'hidden',
+          boxShadow: '0 20px 50px rgba(0,0,0,0.5)',
+          padding: 12, fontFamily: 'var(--font-mono)', fontSize: 7, color: '#444',
+          lineHeight: 1.5,
+        }}>
+          <div style={{ fontWeight: 700, fontSize: 8, marginBottom: 4 }}>WK 3 · FB1</div>
+          <div style={{ borderBottom: '1px solid #ccc', marginBottom: 4 }} />
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div key={i} style={{ marginBottom: 1 }}>
+              {(lines[i % Math.max(lines.length, 1)] || '').slice(0, 22)}
+            </div>
+          ))}
+          <div className="scan-sweep" style={{
+            position: 'absolute', left: 0, right: 0, height: 30,
+            background: 'linear-gradient(180deg, transparent, rgba(197,242,62,0.6), transparent)',
+            top: `${(phase + 1) * 22}%`, transition: 'top 600ms',
+          }} />
+        </div>
+      </div>
+
+      <div style={{ padding: '0 24px', textAlign: 'center', flex: 1 }}>
+        <h1 style={{
+          fontSize: 24, fontWeight: 600, letterSpacing: -0.4,
+          margin: 0, marginBottom: 8,
+        }}>Parsing your program</h1>
+        <p style={{ fontSize: 13, color: 'var(--text-2)', margin: 0, marginBottom: 28 }}>
+          Hang tight — this usually takes a few seconds.
+        </p>
+
+        <div style={{
+          display: 'flex', flexDirection: 'column', gap: 8,
+          maxWidth: 280, margin: '0 auto',
+        }}>
+          {phases.map((p, i) => (
+            <div key={i} style={{
+              display: 'flex', alignItems: 'center', gap: 12,
+              padding: '12px 14px', borderRadius: 14,
+              background: i === phase ? 'rgba(197,242,62,0.06)' : 'transparent',
+              border: '1px solid ' + (i === phase ? 'rgba(197,242,62,0.2)' : 'transparent'),
+              transition: 'all 300ms',
+            }}>
+              <div style={{
+                width: 18, height: 18, borderRadius: 9999,
+                background: i < phase ? 'var(--accent)' : 'transparent',
+                border: '1.5px solid ' + (i <= phase ? 'var(--accent)' : 'var(--text-dim)'),
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                position: 'relative', flexShrink: 0,
+              }}>
+                {i < phase && <Icon name="check" size={11} stroke="var(--on-accent)" strokeWidth={3} />}
+                {i === phase && (
+                  <div className="spin-ring" style={{
+                    position: 'absolute', inset: -3, borderRadius: 9999,
+                    border: '2px solid transparent', borderTopColor: 'var(--accent)',
+                  }} />
+                )}
+              </div>
+              <span style={{
+                fontSize: 13, textAlign: 'left', flex: 1,
+                color: i <= phase ? 'var(--text-1)' : 'var(--text-3)',
+                fontWeight: i === phase ? 600 : 400,
+              }}>{p}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ padding: '0 24px', textAlign: 'center' }}>
+        <p style={{
+          fontSize: 11, color: 'var(--text-3)', margin: 0,
+          fontFamily: 'var(--font-mono)',
+        }}>PROCESSING ON-DEVICE · NO DATA LEAVES YOUR PHONE</p>
+      </div>
+    </Screen>
+  );
+};
+
+Object.assign(window, { AddProgramScreen, CameraScreen, ParsingScreen });

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -268,7 +268,7 @@ const NameScreen = ({ auth, onContinue, onBack }) => {
 // 4. Done — placeholder so the flow has somewhere to land. Real
 //    next step is glasses pairing, owned by a different ticket.
 // ─────────────────────────────────────────────────────────────
-const DoneScreen = ({ auth, onRestart }) => (
+const DoneScreen = ({ auth, onAddProgram, onRestart }) => (
   <Screen padTop={0} padBottom={0} style={{ display: 'flex', flexDirection: 'column' }}>
     <div style={{
       flex: 1, display: 'flex', flexDirection: 'column',
@@ -287,10 +287,11 @@ const DoneScreen = ({ auth, onRestart }) => (
         You're in{auth.user && auth.user.name ? `, ${auth.user.name}` : ''}.
       </h1>
       <p style={{ fontSize: 14, color: 'var(--text-2)', margin: 0, maxWidth: 280 }}>
-        Setup's done. The home screen and the rest of the app come next.
+        Add your first program to get going. The home screen comes later.
       </p>
     </div>
-    <div style={{ padding: '0 24px 40px' }}>
+    <div style={{ padding: '0 24px 40px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <Button onClick={onAddProgram} iconRight="arrow-right">Add a program</Button>
       <Button variant="ghost" onClick={onRestart}>Restart flow</Button>
     </div>
   </Screen>

--- a/ios/tokens.css
+++ b/ios/tokens.css
@@ -20,6 +20,13 @@
   --accent-glow: 0 0 32px rgba(197, 242, 62, 0.35);
   --on-accent: #0A0A0A;
 
+  /* Hero card — used by the "Take a photo" CTA on the add-program screen. */
+  --hero-bg: linear-gradient(165deg, #1B2410 0%, #141414 60%);
+  --hero-border: rgba(197, 242, 62, 0.18);
+
+  /* Semantic */
+  --warn: #FFC462;
+
   /* Subtle white-tint overlays */
   --overlay-1: rgba(255,255,255,0.05);
   --overlay-2: rgba(255,255,255,0.06);
@@ -38,6 +45,9 @@
   --r-card-lg: 28px;
   --r-chip: 12px;
 }
+
+.tnum { font-variant-numeric: tabular-nums; font-feature-settings: 'tnum'; }
+.mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 
 * { box-sizing: border-box; -webkit-font-smoothing: antialiased; }
 
@@ -63,3 +73,12 @@
 /* Spinner ring around the pair indicator while it's searching. */
 @keyframes spinRing { to { transform: rotate(360deg); } }
 .spin-ring { animation: spinRing 1.4s linear infinite; }
+
+/* Sweeping scan line on the parsing screen's preview thumb. */
+@keyframes scanSweep {
+  0%   { top: 0%;   opacity: 0; }
+  10%  { opacity: 1; }
+  90%  { opacity: 1; }
+  100% { top: 100%; opacity: 0; }
+}
+.scan-sweep { animation: scanSweep 2.4s ease-in-out infinite; }

--- a/ios/ui.jsx
+++ b/ios/ui.jsx
@@ -15,9 +15,29 @@ const Icon = ({ name, size = 20, stroke = 'currentColor', strokeWidth = 1.75, st
     case 'bolt':        return <svg {...common}><path d="M13 2L4 14h7l-1 8 9-12h-7l1-8z"/></svg>;
     case 'check':       return <svg {...common}><path d="M5 12l5 5L20 7"/></svg>;
     case 'glasses':     return <svg {...common}><circle cx="6.5" cy="14" r="3.5"/><circle cx="17.5" cy="14" r="3.5"/><path d="M10 14c.5-1 1.5-1 2 0M3 9l3.5-2M21 9l-3.5-2"/></svg>;
+    case 'x':           return <svg {...common}><path d="M6 6l12 12M6 18L18 6"/></svg>;
+    case 'camera':      return <svg {...common}><path d="M3 7h4l2-3h6l2 3h4v12H3V7z"/><circle cx="12" cy="13" r="4"/></svg>;
+    case 'upload':      return <svg {...common}><path d="M12 15V4M7 9l5-5 5 5"/><path d="M5 17v3h14v-3"/></svg>;
+    case 'sparkle':     return <svg {...common}><path d="M12 3v4M12 17v4M3 12h4M17 12h4M5.5 5.5l2.5 2.5M16 16l2.5 2.5M5.5 18.5L8 16M16 8l2.5-2.5"/></svg>;
+    case 'chevron-right': return <svg {...common}><path d="M9 6l6 6-6 6"/></svg>;
+    case 'flash':       return <svg {...common}><path d="M13 2L4 14h7l-1 8 9-12h-7l1-8z" fill={stroke}/></svg>;
+    case 'image':       return <svg {...common}><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="9" cy="10" r="1.5"/><path d="M21 16l-5-5-9 9"/></svg>;
+    case 'rotate':      return <svg {...common}><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg>;
     default: return null;
   }
 };
+
+const Pill = ({ children, accent, style = {} }) => (
+  <span style={{
+    display: 'inline-flex', alignItems: 'center', gap: 6,
+    height: 24, padding: '0 10px', borderRadius: 9999,
+    fontSize: 11, fontWeight: 500, letterSpacing: 0.2,
+    background: accent ? 'var(--accent-soft)' : 'var(--overlay-2)',
+    color: accent ? 'var(--accent)' : 'var(--text-2)',
+    border: '1px solid ' + (accent ? 'rgba(197,242,62,0.3)' : 'var(--hairline)'),
+    ...style,
+  }}>{children}</span>
+);
 
 const Card = ({ children, style = {}, padding = 20, onClick }) => (
   <div onClick={onClick} className={onClick ? 'press' : ''} style={{
@@ -85,4 +105,4 @@ const Field = ({ label, icon, type = 'text', value, onChange, placeholder, trail
   </div>
 );
 
-Object.assign(window, { Icon, Card, Button, Field });
+Object.assign(window, { Icon, Pill, Card, Button, Field });


### PR DESCRIPTION
Closes #51, closes #52, closes #53, closes #54, closes #55, closes #56, closes #57.

## What's in this
The four screens of the "add a program" flow, based on the latest TrainAR design handoff:

- **Entry** ([screens-add-program.jsx](ios/screens-add-program.jsx)) — source picker with Take a photo / Upload a file / Browse community
- **Camera** — UI overlay (close, flash, capture, viewfinder reticles, "program detected" hint pill); the rotated paper page in the middle is a **placeholder** for the live camera feed
- **Parsing** — phases ticker (reading → identifying → parsing → structuring) on a fake timer, with a sweeping scan line on the preview thumb
- **Review** — title + author + Parsed badge, stats grid, weekly schedule, flagged-for-review block, Discard / Save program CTAs

Plus shared bits:
- Hero gradient, warn color, `--r-card-lg`, `scan-sweep` keyframe → [tokens.css](ios/tokens.css)
- New icons (x, camera, upload, sparkle, chevron-right, flash, image, rotate) + `Pill` primitive → [ui.jsx](ios/ui.jsx)
- Sample parsed-program data → [data.js](ios/data.js)
- Wired into the state machine + a launcher button on Done → [app.jsx](ios/app.jsx)

## What's NOT in this (backend's job)
- Real camera feed (the paper placeholder gets swapped for `<video>` once getUserMedia / native bridge exists)
- Real file picker for "Upload a file" (currently shortcuts straight into parsing)
- Real OCR / parser (parsing is timer-driven, review reads from `window.PARSED_PROGRAM` — backend swaps that object for real output)

## Test plan
- [x] Done → "Add a program" lands on entry screen
- [x] "Take a photo" → camera screen with full chrome (close, flash, hint, reticles, capture)
- [x] Capture → parsing → review (animated, ~4s)
- [x] Review shows title, author, stats grid (10 / 5 / 47), 7-day schedule, 2 flagged items
- [x] Save program → back to Done
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)