### PR TITLE
Wire main app shell — tabs, nav stack, workout state

### DIFF
--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -1,33 +1,83 @@
-// App — wires the signup + add-program screens into the iPhone frame.
+// App — wires every screen into the iPhone frame.
 //
-// Tiny state machine:
-//   splash → auth → name → pair → done
-//   done → add → camera → parsing → review → done
+// State machine (high level):
+//   signup phase: splash → auth → name → pair → home
+//   main phase:   tab roots (home / calendar / profile) + a small nav stack
+//                 for sub-screens (add a program flow, program detail, past
+//                 workout summary)
 //
-// `mode` decides whether the auth screen opens in signup or sign-in mode.
+// Workout state (loadedToGlasses) lives at the app level so:
+//   * the Train tab icon can pulse when a workout is live
+//   * HomeScreen + ProgramViewScreen both reflect the same state without
+//     needing to share a parent component
 
 const PROTOTYPE_W = 402;
 const PROTOTYPE_H = 874;
 
+const TAB_ROOTS = ['home', 'calendar', 'profile'];
+
+// Tab roots — the bottom-tab pages. Sub-screens stack on top of these.
+const SCREENS_WITH_TABBAR = TAB_ROOTS;
+
+// All known screens. If a screen isn't a tab root, hitting back pops it
+// off the stack to whatever was underneath.
+const SIGNUP_SCREENS = ['splash', 'auth', 'name', 'pair'];
+
 function App() {
   const auth = useAuth();
-  const [screen, setScreen] = React.useState('splash');
+
+  // Where in the flow are we? Start at splash unless there's already a
+  // signed-in user with a name — in that case skip straight to home.
+  const initialScreen = (() => {
+    if (auth.user && auth.user.name) return 'home';
+    return 'splash';
+  })();
+  const [screen, setScreen] = React.useState(initialScreen);
+
+  // Bottom-tab state — only matters when on a tab root.
+  const [activeTab, setActiveTab] = React.useState('home');
+
+  // Auth screen mode.
   const [mode, setMode] = React.useState('signup');
 
-  // If a returning user already has a name, skip ahead to "done" on first render.
-  // Easy to remove once the rest of the app exists to land them in.
-  React.useEffect(() => {
-    if (auth.user && auth.user.name && screen === 'splash') setScreen('done');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // Workout-active flag. True from "Start workout" → "Finish workout".
+  const [loadedToGlasses, setLoadedToGlasses] = React.useState(false);
+
+  // Nav stack for the main phase. Pushing a sub-screen records what we
+  // were on so the back button knows where to land.
+  const [stack, setStack] = React.useState([]);
+
+  const go = (next) => {
+    setStack((prev) => [...prev, screen]);
+    setScreen(next);
+  };
+
+  const back = () => {
+    setStack((prev) => {
+      const copy = [...prev];
+      const last = copy.pop();
+      if (last) setScreen(last);
+      else setScreen(activeTab); // bail out to the current tab if stack is empty
+      return copy;
+    });
+  };
+
+  const switchTab = (tabId) => {
+    setActiveTab(tabId);
+    setScreen(tabId);
+    setStack([]);
+  };
 
   const restart = () => {
     auth.signOut();
+    setLoadedToGlasses(false);
     setScreen('splash');
+    setStack([]);
     setMode('signup');
   };
 
   const screens = {
+    // ── Signup phase ────────────────────────────────────────────
     splash: (
       <SplashScreen
         onSignUp={() => { setMode('signup'); setScreen('auth'); }}
@@ -51,25 +101,34 @@ function App() {
     ),
     pair: (
       <PairScreen
-        onContinue={() => setScreen('done')}
-        onSkip={() => setScreen('done')}
+        onContinue={() => switchTab('home')}
+        onSkip={() => switchTab('home')}
         onBack={() => setScreen(auth.user && auth.user.name ? 'name' : 'auth')}
       />
     ),
-    done: (
-      <DoneScreen
-        auth={auth}
-        onAddProgram={() => setScreen('add')}
-        onRestart={restart}
+
+    // ── Tab roots ───────────────────────────────────────────────
+    home: (
+      <HomeScreen
+        glassesConnected={true}
+        loadedToGlasses={loadedToGlasses}
+        onAddProgram={() => go('add')}
+        onOpenProgram={() => go('detail')}
+        // Quick-start from the round green glasses button stays on home —
+        // the screen re-renders into the active hero card.
+        onActivate={() => setLoadedToGlasses(true)}
+        onFinish={() => { setLoadedToGlasses(false); go('past'); }}
       />
     ),
+    calendar: <CalendarScreen onOpenWorkout={() => go('past')} />,
+    profile:  <ProfileScreen user={auth.user} />,
 
-    // ── Add a program ───────────────────────────────────────────
+    // ── Add-program flow (sub-screens of home) ──────────────────
     add: (
       <AddProgramScreen
         onCamera={() => setScreen('camera')}
         onUpload={() => setScreen('parsing')}
-        onClose={() => setScreen('done')}
+        onClose={back}
       />
     ),
     camera: (
@@ -81,19 +140,56 @@ function App() {
     parsing: <ParsingScreen onDone={() => setScreen('review')} />,
     review: (
       <ReviewScreen
-        onConfirm={() => setScreen('done')}
-        onClose={() => setScreen('done')}
+        // After save, take them to the detail view of what they just imported.
+        onConfirm={() => { setStack([]); setScreen('detail'); }}
+        onClose={() =>   { setStack([]); setScreen('home'); setActiveTab('home'); }}
       />
     ),
+    failed: (
+      <FailedScanScreen
+        onRetry={() => setScreen('camera')}
+        onClose={() => { setStack([]); setScreen('home'); setActiveTab('home'); }}
+      />
+    ),
+
+    // ── Program detail + past workout ───────────────────────────
+    detail: (
+      <ProgramViewScreen
+        loadedToGlasses={loadedToGlasses}
+        onClose={back}
+        onStartWorkout={() => setLoadedToGlasses(true)}
+        onFinishWorkout={() => { setLoadedToGlasses(false); go('past'); }}
+        onDiscard={() => { setStack([]); setScreen('home'); setActiveTab('home'); }}
+      />
+    ),
+    past: <PastWorkoutScreen onBack={back} />,
   };
 
+  const showTabBar = SCREENS_WITH_TABBAR.includes(screen);
+  const showSignoutDev = !SIGNUP_SCREENS.includes(screen) && screen !== 'pair';
+
   return (
-    <div style={{ padding: 32 }}>
+    <div style={{ padding: 32, position: 'relative' }}>
       <IOSDevice width={PROTOTYPE_W} height={PROTOTYPE_H} dark={true}>
         <div style={{ width: '100%', height: '100%', position: 'relative', background: 'var(--bg)', color: 'var(--text-1)' }}>
           {screens[screen]}
+          {showTabBar && (
+            <TabBar active={activeTab} live={loadedToGlasses} onTab={switchTab} />
+          )}
         </div>
       </IOSDevice>
+
+      {/* Tiny dev affordance — sign out + reset, so the prototype can be
+          replayed from splash without clearing localStorage by hand. */}
+      {showSignoutDev && (
+        <button onClick={restart} style={{
+          position: 'absolute', top: 8, right: 8,
+          padding: '6px 10px', borderRadius: 9999,
+          background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)',
+          color: 'rgba(255,255,255,0.7)', fontSize: 11, cursor: 'pointer',
+          fontFamily: 'var(--font-sans)',
+        }}>Reset prototype</button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #67. Closes #59.

Final wiring branch — pulls together everything we've built across the v2 refresh.

## Changes
- `app.jsx` rewritten:
  - signup phase ends at the Train tab (not the placeholder Done screen)
  - three tab roots (home / calendar / profile) with the bottom TabBar over them
  - small nav stack for sub-screens (add-program flow, program detail, past workout summary)
  - `loadedToGlasses` lives at the app level so:
    - the Train tab icon pulses lime when a workout is live
    - HomeScreen re-renders into its hero "workout in progress" state
    - ProgramViewScreen shows Finish workout instead of Start
  - back button pops the stack; falls back to the active tab if empty
  - review save → detail (so users see what they just imported)
  - small "Reset prototype" affordance in the corner so the demo can be replayed from splash without clearing localStorage by hand
  - returning users with a name skip splash and land on home directly

## Test plan
- [x] Cold start: splash → auth → name → pair → home (verified end-to-end in preview)
- [x] Tap a program on home → detail shows Saved + Start workout
- [x] Start workout → detail shows Workout in progress + Finish workout
- [x] Finish workout → past workout summary
- [x] Back from past → detail; back again → home
- [x] Tabs switch: Train → History → Profile all render the right content
- [x] Add a program from home → flow lands back home (verified flow renders correctly)
- [x] No console errors from the app itself (only sandbox warnings from preview-only test code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)