### PR TITLE
Voice coach: iPhone → Flask → Supabase wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ OPENAI_API_KEY=
 OPENAI_NORMALIZER_MODEL=gpt-4.1
 GROQ_API_KEY=
 GROQ_NORMALIZER_MODEL=openai/gpt-oss-120b
+
+# Voice coach -> Supabase
+# These must point at the same project the iOS web app uses.
+SUPABASE_URL=
+SUPABASE_ANON_KEY=

--- a/DONE.txt
+++ b/DONE.txt
@@ -1,0 +1,6 @@
+COMPLETE
+
+Voice coach iPhone-mode end-to-end wiring landed.
+
+Plan: /Users/charlieabowd/.claude/plans/ok-i-want-you-peppy-gosling.md
+Verification: docs/voice-coach-demo.md

--- a/docs/voice-coach-demo.md
+++ b/docs/voice-coach-demo.md
@@ -1,0 +1,88 @@
+# Voice coach: manual verification
+
+This branch wires the voice coach end-to-end in iPhone mode (no Meta DAT SDK,
+no glasses). The acceptance bar is: **say "log a set: 5 reps at 135 on bench"
+into the native app and see that set appear in the History tab.**
+
+## One-time setup
+
+1. Create a Supabase access token in `.env`:
+
+   ```env
+   SUPABASE_URL=https://rcmlbgjqwpfzpiownxfy.supabase.co
+   SUPABASE_ANON_KEY=<anon key, same one ios/supabase.js embeds>
+   ```
+
+   Use the same project the iOS web app already points at
+   (`ios/supabase.js:5-6`). The anon key is safe to put in `.env` — RLS keeps
+   writes scoped to `auth.uid()`.
+
+2. Install Python deps:
+
+   ```bash
+   pip install -e .
+   ```
+
+   (`supabase` and `PyJWT` are now in `pyproject.toml`.)
+
+3. Open `native-ios/TrainAR/TrainAR.xcodeproj` in Xcode at least once so the
+   simulator/device is provisioned with your dev team.
+
+## Running the demo
+
+```bash
+# Terminal 1 — backend (also serves the iOS web app at /ios/)
+python -m src.main --demo --host 0.0.0.0 --port 5002
+```
+
+In Xcode, run TrainAR on a simulator. The default
+`Info.plist:TRAINAR_WEB_URL` is `http://127.0.0.1:5002/ios/`. If you're
+testing on a physical iPhone over Wi-Fi, change that key in the project
+settings to your Mac's `:5002/ios/` URL.
+
+1. Sign in to your Supabase account in the web view (same flow as before).
+2. On the Train tab you should now see a green floating mic button at the
+   bottom right.
+3. Tap it. The app will prompt for mic + speech recognition access the first
+   time.
+4. Say: **"log a set: 5 reps at 135 on bench"**
+5. The coach should speak back "Logged 5 reps of bench press at 135 pounds."
+6. Switch to the History tab and confirm today's session shows bench press
+   5 × 135.
+7. In Supabase Studio, open `workout_sessions`, `workout_exercise_logs`, and
+   `workout_sets` — there should be one new row in each, all tied to your
+   `auth.uid()`.
+
+## What the loop does, file-by-file
+
+| Step | File | Function |
+|---|---|---|
+| 1. Mic tap | [ios/screens-main.jsx](../ios/screens-main.jsx) | `CoachMicFab` sends `startListening` to native |
+| 2. Speech → transcript | [native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift](../native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift) | `startListening()` runs `SFSpeechRecognizer`, emits `voiceCommand` |
+| 3. Transcript → coach | [ios/app.jsx](../ios/app.jsx) | `onGlassesEvent` calls `askTrainARCoach(transcript)` |
+| 4. JWT-stamped POST | [ios/assistant.js](../ios/assistant.js) | Attaches `Bearer <supabase access token>` |
+| 5. Flask route | [src/app/program_review/web_demo.py](../src/app/program_review/web_demo.py) | `assistant_chat_api` parses JWT, builds Supabase client, threads context |
+| 6. Tool dispatch | [src/assistant/service.py](../src/assistant/service.py) | `_execute_action` passes context into the tool |
+| 7. Supabase write | [src/assistant/tools.py](../src/assistant/tools.py) | `log_set` creates session + exercise log + set under `auth.uid()` |
+| 8. Spoken reply | [native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift](../native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift) | `speakResponse` → `AVSpeechSynthesizer` |
+| 9. UI refresh | [ios/assistant.js](../ios/assistant.js) → [ios/app.jsx](../ios/app.jsx) | `trainar:history-changed` event re-runs `loadTrainarData` |
+
+## Browser-only fallback
+
+You don't need the native shell to demo the rest of the stack:
+
+```bash
+python -m src.main --demo --host 127.0.0.1 --port 5002
+# open http://127.0.0.1:5002/ios/ in Safari/Chrome
+```
+
+The mic button falls back to a `prompt()` text box. Sign in, then type any
+of the commands the assistant understands. The JWT forwarding + Supabase
+writes work the same way.
+
+## Known follow-ups (out of scope for this branch)
+
+- Meta DAT SDK integration — glasses code paths are still mocked.
+- A nicer in-app listening UI (waveform, "tap to stop").
+- Surface tool errors (e.g. `supabase_error`) inline in the chat overlay.
+- Wake-word ("hey trainar") instead of tap-to-talk.

--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -200,15 +200,25 @@ function App() {
       setCoachResponse(event.detail || null);
     };
 
+    const onHistoryChanged = () => {
+      if (auth.user && window.loadTrainarData) {
+        window.loadTrainarData(auth.user.id).catch((err) => {
+          console.error('Could not reload TrainAR data after coach action:', err);
+        });
+      }
+    };
+
     window.addEventListener('trainar:glasses-state', onGlassesState);
     window.addEventListener('trainar:glasses', onGlassesEvent);
     window.addEventListener('trainar:coach-response', onCoachResponse);
+    window.addEventListener('trainar:history-changed', onHistoryChanged);
     return () => {
       window.removeEventListener('trainar:glasses-state', onGlassesState);
       window.removeEventListener('trainar:glasses', onGlassesEvent);
       window.removeEventListener('trainar:coach-response', onCoachResponse);
+      window.removeEventListener('trainar:history-changed', onHistoryChanged);
     };
-  }, [activeProgramId, selectedProgramId, activeSessionId, loadedToGlasses]);
+  }, [activeProgramId, selectedProgramId, activeSessionId, loadedToGlasses, auth.user]);
 
   const openWorkout = async (sessionId) => {
     if (window.selectPastWorkout) {
@@ -380,6 +390,7 @@ function App() {
       {showTabBar && (
         <TabBar active={activeTab} live={loadedToGlasses} onTab={switchTab} />
       )}
+      {showTabBar && auth.user && window.CoachMicFab && <CoachMicFab />}
       {coachResponse?.response && (
         <CoachOverlay
           response={coachResponse.response}

--- a/ios/assistant.js
+++ b/ios/assistant.js
@@ -5,15 +5,35 @@
 // the local assistant endpoint so coach responses can refer to saved programs,
 // workout history, PRs, and device state.
 (function () {
+  async function getSupabaseAccessToken() {
+    const client = window.trainarSupabase;
+    if (!client || !client.auth || typeof client.auth.getSession !== 'function') {
+      return null;
+    }
+    try {
+      const { data, error } = await client.auth.getSession();
+      if (error) return null;
+      return data && data.session ? data.session.access_token : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
   async function askTrainARCoach(message, options = {}) {
     const cleanMessage = String(message || '').trim();
     if (!cleanMessage) {
       throw new Error('Message is required.');
     }
 
+    const headers = { 'Content-Type': 'application/json' };
+    const accessToken = await getSupabaseAccessToken();
+    if (accessToken) {
+      headers['Authorization'] = 'Bearer ' + accessToken;
+    }
+
     const response = await fetch('/api/assistant/chat', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({
         message: cleanMessage,
         context: buildCoachContext(options),
@@ -29,10 +49,26 @@
       detail: payload,
     }));
 
+    // Ask the native shell to speak the reply via AVSpeechSynthesizer.
+    window.dispatchEvent(new CustomEvent('trainar:speak', {
+      detail: { text: payload.response || '' },
+    }));
+
     if (window.sendTrainARNativeCommand) {
       window.sendTrainARNativeCommand('coachResponse', {
         response: payload.response || '',
       });
+      if (payload.response) {
+        window.sendTrainARNativeCommand('speakResponse', {
+          text: payload.response,
+        });
+      }
+    }
+
+    // Trigger a History refresh so newly-written sets show up.
+    const action = (payload.action && payload.action.action) || '';
+    if (['log_set', 'finish_workout', 'start_workout', 'start_exercise'].includes(action)) {
+      window.dispatchEvent(new CustomEvent('trainar:history-changed'));
     }
 
     return payload;

--- a/ios/screens-main.jsx
+++ b/ios/screens-main.jsx
@@ -216,4 +216,57 @@ const HomeScreen = ({
   );
 };
 
-Object.assign(window, { HomeScreen });
+// Floating mic button. When the native shell is attached we ask it to start
+// SFSpeechRecognizer via the `startListening` command; otherwise we fall back
+// to a textarea prompt so the loop is demoable in a plain browser too.
+const CoachMicFab = () => {
+  const [busy, setBusy] = React.useState(false);
+  const isNative = typeof window !== 'undefined' && window.TRAINAR_NATIVE_APP === true;
+
+  const sendTranscript = async (transcript) => {
+    if (!transcript || !window.askTrainARCoach) return;
+    setBusy(true);
+    try {
+      await window.askTrainARCoach(transcript);
+    } catch (err) {
+      console.error('Coach call failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onClick = () => {
+    if (busy) return;
+    if (isNative && window.sendTrainARNativeCommand) {
+      window.sendTrainARNativeCommand('startListening', {});
+      return;
+    }
+    const transcript = window.prompt('What should the coach do?', 'log a set: 5 reps at 135 on bench');
+    if (transcript) sendTranscript(transcript);
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      aria-label={isNative ? 'Talk to coach' : 'Type a coach command'}
+      style={{
+        position: 'fixed', right: 18, bottom: 92, zIndex: 50,
+        width: 56, height: 56, borderRadius: '50%',
+        background: busy ? 'var(--surface-2)' : 'var(--accent)',
+        color: 'var(--on-accent)', border: 'none',
+        boxShadow: '0 6px 18px rgba(0,0,0,0.35)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        cursor: busy ? 'wait' : 'pointer',
+      }}
+    >
+      <Icon
+        name={isNative ? 'glasses' : 'plus'}
+        size={24}
+        stroke={busy ? 'var(--text-2)' : 'var(--on-accent)'}
+        strokeWidth={2.4}
+      />
+    </button>
+  );
+};
+
+Object.assign(window, { HomeScreen, CoachMicFab });

--- a/native-ios/TrainAR/TrainAR.xcodeproj/project.pbxproj
+++ b/native-ios/TrainAR/TrainAR.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3A1000030000000000000001 /* TrainARWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000130000000000000001 /* TrainARWebView.swift */; };
 		3A1000040000000000000001 /* GlassesBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000140000000000000001 /* GlassesBridge.swift */; };
 		3A1000050000000000000001 /* MetaWearablesBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000150000000000000001 /* MetaWearablesBridge.swift */; };
+		3A1000060000000000000001 /* AppleVoiceBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000170000000000000001 /* AppleVoiceBridge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		3A1000140000000000000001 /* GlassesBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassesBridge.swift; sourceTree = "<group>"; };
 		3A1000150000000000000001 /* MetaWearablesBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaWearablesBridge.swift; sourceTree = "<group>"; };
 		3A1000160000000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3A1000170000000000000001 /* AppleVoiceBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleVoiceBridge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +53,7 @@
 				3A1000130000000000000001 /* TrainARWebView.swift */,
 				3A1000140000000000000001 /* GlassesBridge.swift */,
 				3A1000150000000000000001 /* MetaWearablesBridge.swift */,
+				3A1000170000000000000001 /* AppleVoiceBridge.swift */,
 				3A1000160000000000000001 /* Info.plist */,
 			);
 			path = TrainAR;
@@ -137,6 +140,7 @@
 				3A1000030000000000000001 /* TrainARWebView.swift in Sources */,
 				3A1000040000000000000001 /* GlassesBridge.swift in Sources */,
 				3A1000050000000000000001 /* MetaWearablesBridge.swift in Sources */,
+				3A1000060000000000000001 /* AppleVoiceBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
+++ b/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
@@ -1,0 +1,228 @@
+import AVFoundation
+import Combine
+import Foundation
+import Speech
+
+/// Apple-only voice bridge used in iPhone-mode (no DAT SDK, no glasses).
+///
+/// Lifecycle:
+///   * `connect()` requests mic + speech recognition permission and emits
+///     a `connected` event so the web UI can show the green pill.
+///   * Web sends `startListening` → we run an AVAudioEngine + SFSpeech tap
+///     and emit a `voiceCommand` event with the final transcript.
+///   * Web sends `speakResponse` → we synthesise the text on-device.
+final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelegate {
+    @Published private(set) var isConnected: Bool = false
+
+    private let stream: AsyncStream<GlassesBridgeEvent>
+    private let continuation: AsyncStream<GlassesBridgeEvent>.Continuation
+
+    private let audioEngine = AVAudioEngine()
+    private let synthesizer = AVSpeechSynthesizer()
+    private let recognizer: SFSpeechRecognizer?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var lastTranscript: String = ""
+
+    var events: AsyncStream<GlassesBridgeEvent> { stream }
+
+    override init() {
+        var cont: AsyncStream<GlassesBridgeEvent>.Continuation!
+        self.stream = AsyncStream { cont = $0 }
+        self.continuation = cont
+        self.recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        super.init()
+        self.synthesizer.delegate = self
+    }
+
+    // MARK: - GlassesBridge
+
+    func connect() {
+        Task { @MainActor in
+            let mic = await Self.requestMicrophonePermission()
+            let speech = await Self.requestSpeechAuthorization()
+
+            if mic && speech == .authorized {
+                self.isConnected = true
+                self.emit(type: "connected", payload: [
+                    "deviceName": "iPhone Voice",
+                    "battery": "100"
+                ])
+            } else {
+                self.isConnected = false
+                self.emit(type: "permissionDenied", payload: [
+                    "mic": mic ? "granted" : "denied",
+                    "speech": Self.describe(speech)
+                ])
+            }
+        }
+    }
+
+    func disconnect() {
+        stopListening()
+        isConnected = false
+        emit(type: "disconnected", payload: ["deviceName": "iPhone Voice"])
+    }
+
+    func replayState() {
+        if isConnected {
+            emit(type: "connected", payload: ["deviceName": "iPhone Voice", "battery": "100"])
+        } else {
+            emit(type: "disconnected", payload: ["deviceName": "iPhone Voice"])
+        }
+    }
+
+    func handleWebCommand(type: String, payload: Any?) {
+        let body = payload as? [String: Any]
+        switch type {
+        case "startListening":
+            startListening()
+        case "stopListening":
+            stopListening()
+        case "speakResponse":
+            let text = (body?["text"] as? String) ?? ""
+            speak(text: text)
+        case "mockConnect":
+            connect()
+        case "mockDisconnect":
+            disconnect()
+        default:
+            emit(type: "webCommandReceived", payload: ["command": type])
+        }
+    }
+
+    // MARK: - Speech recognition
+
+    private func startListening() {
+        guard isConnected else {
+            connect()
+            return
+        }
+        guard let recognizer, recognizer.isAvailable else {
+            emit(type: "voiceError", payload: ["message": "Speech recognizer unavailable"])
+            return
+        }
+        if recognitionTask != nil {
+            stopListening()
+        }
+
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            emit(type: "voiceError", payload: ["message": "audio session: \(error.localizedDescription)"])
+            return
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        recognitionRequest = request
+        lastTranscript = ""
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+        }
+
+        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            if let result {
+                let transcript = result.bestTranscription.formattedString
+                self.lastTranscript = transcript
+                if result.isFinal {
+                    self.finishTranscript(transcript)
+                }
+            }
+            if error != nil {
+                self.finishTranscript(self.lastTranscript)
+            }
+        }
+
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+            emit(type: "listening", payload: ["state": "started"])
+        } catch {
+            emit(type: "voiceError", payload: ["message": "audio engine: \(error.localizedDescription)"])
+            stopListening()
+        }
+    }
+
+    private func stopListening() {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        emit(type: "listening", payload: ["state": "stopped"])
+    }
+
+    private func finishTranscript(_ transcript: String) {
+        stopListening()
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        emit(type: "voiceCommand", payload: ["transcript": trimmed])
+    }
+
+    // MARK: - TTS
+
+    private func speak(text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if synthesizer.isSpeaking {
+            synthesizer.stopSpeaking(at: .immediate)
+        }
+        let utterance = AVSpeechUtterance(string: trimmed)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+        synthesizer.speak(utterance)
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        emit(type: "spoke", payload: ["text": utterance.speechString])
+    }
+
+    // MARK: - Helpers
+
+    private func emit(type: String, payload: [String: String]) {
+        continuation.yield(GlassesBridgeEvent(type: type, payload: payload))
+    }
+
+    private static func requestMicrophonePermission() async -> Bool {
+        await withCheckedContinuation { cont in
+            if #available(iOS 17.0, *) {
+                AVAudioApplication.requestRecordPermission { granted in
+                    cont.resume(returning: granted)
+                }
+            } else {
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                    cont.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    private static func requestSpeechAuthorization() async -> SFSpeechRecognizerAuthorizationStatus {
+        await withCheckedContinuation { cont in
+            SFSpeechRecognizer.requestAuthorization { status in
+                cont.resume(returning: status)
+            }
+        }
+    }
+
+    private static func describe(_ status: SFSpeechRecognizerAuthorizationStatus) -> String {
+        switch status {
+        case .authorized: return "authorized"
+        case .denied: return "denied"
+        case .notDetermined: return "notDetermined"
+        case .restricted: return "restricted"
+        @unknown default: return "unknown"
+        }
+    }
+}

--- a/native-ios/TrainAR/TrainAR/ContentView.swift
+++ b/native-ios/TrainAR/TrainAR/ContentView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var bridge = MockGlassesBridge()
+    @StateObject private var bridge = AppleVoiceBridge()
 
     var body: some View {
         TrainARWebView(bridge: bridge)
             .ignoresSafeArea()
+            .onAppear { bridge.connect() }
     }
 }

--- a/native-ios/TrainAR/TrainAR/Info.plist
+++ b/native-ios/TrainAR/TrainAR/Info.plist
@@ -42,6 +42,10 @@
 	<string>TrainAR uses Bluetooth to connect to Meta wearable devices.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>TrainAR uses camera input from wearable devices to understand workout context.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>TrainAR listens for short voice commands so you can log sets hands-free during a workout.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>TrainAR transcribes your voice commands on-device so the coach can act on them.</string>
 	<key>TRAINAR_WEB_URL</key>
 	<string>http://127.0.0.1:5002/ios/</string>
 	<key>UIApplicationSceneManifest</key>

--- a/native-ios/TrainAR/TrainAR/TrainARWebView.swift
+++ b/native-ios/TrainAR/TrainAR/TrainARWebView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 import WebKit
 
-struct TrainARWebView: UIViewRepresentable {
-    @ObservedObject var bridge: MockGlassesBridge
+struct TrainARWebView<B: GlassesBridge>: UIViewRepresentable {
+    @ObservedObject var bridge: B
 
-    func makeCoordinator() -> Coordinator {
+    func makeCoordinator() -> Coordinator<B> {
         Coordinator(bridge: bridge)
     }
 
@@ -34,30 +34,44 @@ extension TrainARWebView {
         return URL(string: raw?.isEmpty == false ? raw! : "http://127.0.0.1:5002/ios/")!
     }
 
-    static let bootstrapScript = WKUserScript(
-        source: """
-        window.TRAINAR_NATIVE_APP = true;
-        document.documentElement.classList.add('trainar-native');
-        window.TrainARNative = {
-          postMessage: function(type, payload) {
-            if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.trainarNative) {
-              return;
-            }
-            window.webkit.messageHandlers.trainarNative.postMessage({ type: type, payload: payload || {} });
-          }
-        };
-        """,
-        injectionTime: .atDocumentStart,
-        forMainFrameOnly: true
-    )
+    static var bootstrapScript: WKUserScript {
+        WKUserScript(
+            source: """
+            window.TRAINAR_NATIVE_APP = true;
+            document.documentElement.classList.add('trainar-native');
+            window.TrainARNative = {
+              postMessage: function(type, payload) {
+                if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.trainarNative) {
+                  return;
+                }
+                window.webkit.messageHandlers.trainarNative.postMessage({ type: type, payload: payload || {} });
+              }
+            };
+            window.sendTrainARNativeCommand = function(type, payload) {
+              window.TrainARNative.postMessage(type, payload);
+              return true;
+            };
+            // Forward in-page trainar:speak events to the native bridge so the
+            // coach response gets spoken via AVSpeechSynthesizer.
+            window.addEventListener('trainar:speak', function(event) {
+              var detail = event.detail || {};
+              var text = detail.text || '';
+              if (!text) return;
+              window.TrainARNative.postMessage('speakResponse', { text: text });
+            });
+            """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+    }
 }
 
-final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
-    private let bridge: MockGlassesBridge
+final class Coordinator<B: GlassesBridge>: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+    private let bridge: B
     private weak var webView: WKWebView?
     private var eventTask: Task<Void, Never>?
 
-    init(bridge: MockGlassesBridge) {
+    init(bridge: B) {
         self.bridge = bridge
         super.init()
         startForwardingEvents()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
   "numpy>=1.26,<3.0",
   "opencv-python>=4.9,<5.0",
   "Pillow>=10.0,<12.0",
+  "supabase>=2.0,<3.0",
+  "PyJWT>=2.8,<3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/app/program_review/web_demo.py
+++ b/src/app/program_review/web_demo.py
@@ -8,10 +8,17 @@ import logging
 import tempfile
 import time
 from pathlib import Path
+from typing import Any
 
 from flask import Flask, jsonify, render_template, request, send_from_directory
 
 from src.assistant.service import AssistantUnavailableError, handle_message
+from src.assistant.supabase_client import (
+    SupabaseAuthError,
+    SupabaseConfigError,
+    build_user_client,
+    extract_user_id,
+)
 from src.contracts import TrainingProgram
 from src.ingestion import UnsupportedProgramSourceError, extract_program_file, normalize_extracted_program
 from src.ingestion.llm_normalizer import (
@@ -40,7 +47,7 @@ def create_app() -> Flask:
         if request.path.startswith("/api/"):
             response.headers["Access-Control-Allow-Origin"] = request.headers.get("Origin", "*")
             response.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
-            response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+            response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
         return response
 
     @app.get("/")
@@ -100,16 +107,34 @@ def create_app() -> Flask:
             LOGGER.exception("Unexpected error while parsing uploaded program.")
             return jsonify({"error": "Program parsing failed. Try a clearer file or a text export."}), 500
 
-    @app.post("/api/assistant/chat")
+    @app.route("/api/assistant/chat", methods=["POST", "OPTIONS"])
     def assistant_chat_api():
+        if request.method == "OPTIONS":
+            return ("", 204)
+
         payload = request.get_json(silent=True) or {}
         message = str(payload.get("message", "")).strip()
-        context = payload.get("context") if isinstance(payload.get("context"), dict) else None
+        client_context = payload.get("context") if isinstance(payload.get("context"), dict) else None
         if not message:
             return jsonify({"error": "Message is required."}), 400
 
+        jwt = _extract_bearer_jwt(request.headers.get("Authorization", ""))
+        context: dict[str, Any] = dict(client_context or {})
+
+        if jwt:
+            try:
+                supabase = build_user_client(jwt)
+                user_id = extract_user_id(jwt)
+                context["supabase"] = supabase
+                context["user_id"] = user_id
+            except SupabaseConfigError as exc:
+                LOGGER.warning("Supabase not configured: %s", exc)
+                return jsonify({"error": str(exc)}), 503
+            except SupabaseAuthError as exc:
+                return jsonify({"error": str(exc)}), 401
+
         try:
-            return jsonify(handle_message(message, context=context))
+            return jsonify(handle_message(message, context=context or None))
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
         except AssistantUnavailableError as exc:
@@ -280,6 +305,16 @@ def _write_desktop_parse_cache(
 
 def _desktop_parse_cache_path(cache_key: str) -> Path:
     return DESKTOP_PARSE_CACHE_DIR / f"{cache_key}.json"
+
+
+def _extract_bearer_jwt(header_value: str) -> str | None:
+    if not header_value:
+        return None
+    parts = header_value.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    token = parts[1].strip()
+    return token or None
 
 
 def _is_retryable_llm_error(exc: Exception) -> bool:

--- a/src/assistant/service.py
+++ b/src/assistant/service.py
@@ -88,17 +88,17 @@ def _execute_action(action: AssistantAction, *, context: dict[str, Any] | None =
         contextual_pr = _get_contextual_pr(action.exercise_name, context=context)
         if contextual_pr is not None:
             return contextual_pr
-        return tools.get_pr(action.exercise_name)
+        return tools.get_pr(action.exercise_name, context=context)
     if action.action == "log_set":
-        return tools.log_set(action.exercise_name, action.reps, action.weight)
+        return tools.log_set(action.exercise_name, action.reps, action.weight, context=context)
     if action.action == "start_workout":
-        return tools.start_workout()
+        return tools.start_workout(context=context)
     if action.action == "start_exercise":
-        return tools.start_exercise(action.exercise_name)
+        return tools.start_exercise(action.exercise_name, context=context)
     if action.action == "start_rest":
-        return tools.start_rest(action.duration_seconds)
+        return tools.start_rest(action.duration_seconds, context=context)
     if action.action == "finish_workout":
-        return tools.finish_workout()
+        return tools.finish_workout(context=context)
     if context:
         return _answer_from_context(context)
     return {

--- a/src/assistant/supabase_client.py
+++ b/src/assistant/supabase_client.py
@@ -1,0 +1,83 @@
+"""Per-request Supabase client factory for the voice coach API.
+
+Tools call into Supabase under the authenticated user's JWT so RLS policies
+that key off ``auth.uid()`` apply. This module returns a fresh client whose
+PostgREST headers carry the caller's access token.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    from supabase import Client, create_client
+except ModuleNotFoundError:  # pragma: no cover - import guard for environments without the dep
+    Client = Any  # type: ignore[assignment]
+    create_client = None  # type: ignore[assignment]
+
+
+class SupabaseConfigError(RuntimeError):
+    """Raised when the Supabase URL/anon key are not configured."""
+
+
+class SupabaseAuthError(RuntimeError):
+    """Raised when a request lacks a usable JWT."""
+
+
+def build_user_client(jwt: str) -> "Client":
+    """Return a Supabase client whose requests run as the JWT's user.
+
+    The anon key authorizes the request at the API gateway; the JWT in the
+    ``Authorization`` header is what Postgres sees as ``auth.uid()``.
+    """
+
+    if create_client is None:
+        raise SupabaseConfigError(
+            "supabase python package is not installed. Add `supabase` to requirements."
+        )
+
+    url = os.getenv("SUPABASE_URL", "").strip()
+    anon_key = os.getenv("SUPABASE_ANON_KEY", "").strip()
+    if not url or not anon_key:
+        raise SupabaseConfigError(
+            "SUPABASE_URL and SUPABASE_ANON_KEY must be set for the voice coach API."
+        )
+
+    token = (jwt or "").strip()
+    if not token:
+        raise SupabaseAuthError(
+            "Missing Supabase JWT. Pass it as 'Authorization: Bearer <token>'."
+        )
+
+    client = create_client(url, anon_key)
+    client.postgrest.auth(token)
+    return client
+
+
+def extract_user_id(jwt: str) -> str:
+    """Decode the JWT (no signature check) to read its ``sub`` claim.
+
+    Supabase guarantees the JWT was already verified before our request lands
+    here only when we re-issue calls through PostgREST under that token, so
+    treat this purely as a hint for code that needs the user id before any
+    PostgREST round-trip. RLS is still the source of truth.
+    """
+
+    try:
+        import jwt as pyjwt  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise SupabaseAuthError("PyJWT is required to extract the user id.") from exc
+
+    if not jwt:
+        raise SupabaseAuthError("Empty JWT.")
+
+    try:
+        claims = pyjwt.decode(jwt, options={"verify_signature": False})
+    except Exception as exc:  # pragma: no cover - defensive
+        raise SupabaseAuthError(f"Could not decode JWT: {exc}") from exc
+
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise SupabaseAuthError("JWT is missing the 'sub' claim.")
+    return sub

--- a/src/assistant/tools.py
+++ b/src/assistant/tools.py
@@ -1,14 +1,35 @@
-"""Deterministic assistant tools for workout actions."""
+"""Assistant tools — Supabase-backed when a JWT-scoped client is in context.
+
+If a tool is invoked without ``context['supabase']`` and ``context['user_id']``,
+it falls back to the in-memory mock store. The Flask voice-coach route always
+supplies the real client; pytest paths that exercise the assistant directly
+keep working against the mock.
+"""
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 from src.assistant.mock_db import EXERCISE_ALIASES, LOGGED_SETS, PERSONAL_RECORDS, WORKOUT_STATE
 
 
+def _get_supabase(context: dict[str, Any] | None):
+    if not context:
+        return None, None
+    client = context.get("supabase")
+    user_id = context.get("user_id")
+    if client is None or not user_id:
+        return None, None
+    return client, user_id
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
 def normalize_exercise_name(exercise_name: str | None) -> str | None:
-    """Normalize user-facing exercise names into mock database keys."""
+    """Normalize user-facing exercise names into canonical keys."""
 
     if exercise_name is None:
         return None
@@ -17,9 +38,12 @@ def normalize_exercise_name(exercise_name: str | None) -> str | None:
     return EXERCISE_ALIASES.get(normalized, normalized)
 
 
-def get_pr(exercise_name: str | None) -> dict[str, Any]:
-    """Return a mocked personal record for an exercise."""
+# ---------------------------------------------------------------------------
+# PR lookup
+# ---------------------------------------------------------------------------
 
+
+def get_pr(exercise_name: str | None, *, context: dict[str, Any] | None = None) -> dict[str, Any]:
     normalized_name = normalize_exercise_name(exercise_name)
     if not normalized_name:
         return {
@@ -28,6 +52,43 @@ def get_pr(exercise_name: str | None) -> dict[str, Any]:
             "message": "Which exercise PR do you want to check?",
         }
 
+    client, user_id = _get_supabase(context)
+    if client is not None and user_id is not None:
+        try:
+            response = (
+                client.table("personal_records")
+                .select("exercise_name,value,unit,record_type,achieved_at")
+                .eq("user_id", user_id)
+                .ilike("exercise_name", normalized_name)
+                .order("achieved_at", desc=True)
+                .limit(1)
+                .execute()
+            )
+            rows = response.data or []
+        except Exception as exc:  # pragma: no cover
+            return {
+                "ok": False,
+                "status": "supabase_error",
+                "message": f"Could not read your PR: {exc}",
+            }
+        if not rows:
+            return {
+                "ok": False,
+                "status": "not_found",
+                "exercise_name": normalized_name,
+                "message": f"I do not have a PR saved for {normalized_name}.",
+            }
+        record = rows[0]
+        return {
+            "ok": True,
+            "status": "found",
+            "exercise_name": record.get("exercise_name") or normalized_name,
+            "display_name": record.get("exercise_name") or normalized_name,
+            "weight": float(record["value"]),
+            "unit": record.get("unit") or "lb",
+        }
+
+    # mock fallback
     record = PERSONAL_RECORDS.get(normalized_name)
     if record is None:
         return {
@@ -36,96 +97,91 @@ def get_pr(exercise_name: str | None) -> dict[str, Any]:
             "exercise_name": normalized_name,
             "message": f"I do not have a PR saved for {normalized_name}.",
         }
-
-    return {
-        "ok": True,
-        "status": "found",
-        **record,
-    }
+    return {"ok": True, "status": "found", **record}
 
 
-def log_set(exercise_name: str | None, reps: int | None, weight: float | None) -> dict[str, Any]:
-    """Log a mocked workout set in memory."""
-
-    normalized_name = normalize_exercise_name(exercise_name)
-    if not normalized_name or reps is None or weight is None:
-        return {
-            "ok": False,
-            "status": "missing_fields",
-            "message": "To log a set, I need the exercise, reps, and weight.",
-        }
-
-    logged_set = {
-        "exercise_name": normalized_name,
-        "reps": reps,
-        "weight": weight,
-    }
-    LOGGED_SETS.append(logged_set)
-    return {
-        "ok": True,
-        "status": "logged",
-        **logged_set,
-    }
+# ---------------------------------------------------------------------------
+# Workout lifecycle (sessions)
+# ---------------------------------------------------------------------------
 
 
-def start_workout() -> dict[str, Any]:
-    """Start a mocked workout session."""
-
-    WORKOUT_STATE.update(
-        {
-            "active": True,
-            "resting": False,
-            "rest_duration_seconds": None,
-        }
+def _find_active_session_id(client, user_id: str) -> str | None:
+    response = (
+        client.table("workout_sessions")
+        .select("id")
+        .eq("user_id", user_id)
+        .eq("status", "in_progress")
+        .order("started_at", desc=True)
+        .limit(1)
+        .execute()
     )
+    rows = response.data or []
+    return rows[0]["id"] if rows else None
+
+
+def _create_session(client, user_id: str, *, title: str = "Voice session") -> str:
+    now = _now_iso()
+    response = (
+        client.table("workout_sessions")
+        .insert(
+            {
+                "user_id": user_id,
+                "title": title,
+                "status": "in_progress",
+                "started_at": now,
+            }
+        )
+        .execute()
+    )
+    rows = response.data or []
+    if not rows:
+        raise RuntimeError("workout_sessions insert returned no row")
+    return rows[0]["id"]
+
+
+def start_workout(*, context: dict[str, Any] | None = None) -> dict[str, Any]:
+    client, user_id = _get_supabase(context)
+    if client is not None and user_id is not None:
+        try:
+            existing = _find_active_session_id(client, user_id)
+            session_id = existing or _create_session(client, user_id)
+        except Exception as exc:  # pragma: no cover
+            return {
+                "ok": False,
+                "status": "supabase_error",
+                "message": f"Could not start a session: {exc}",
+            }
+        return {"ok": True, "status": "started", "session_id": session_id}
+
+    WORKOUT_STATE.update({"active": True, "resting": False, "rest_duration_seconds": None})
     return {"ok": True, "status": "started"}
 
 
-def start_exercise(exercise_name: str | None) -> dict[str, Any]:
-    """Set the current mocked exercise."""
+def finish_workout(*, context: dict[str, Any] | None = None) -> dict[str, Any]:
+    client, user_id = _get_supabase(context)
+    if client is not None and user_id is not None:
+        try:
+            session_id = _find_active_session_id(client, user_id)
+            if session_id is None:
+                return {"ok": True, "status": "no_active_session"}
 
-    normalized_name = normalize_exercise_name(exercise_name)
-    if not normalized_name:
-        return {
-            "ok": False,
-            "status": "missing_exercise",
-            "message": "Which exercise should I start?",
-        }
-
-    WORKOUT_STATE.update(
-        {
-            "active": True,
-            "current_exercise": normalized_name,
-            "resting": False,
-            "rest_duration_seconds": None,
-        }
-    )
-    return {
-        "ok": True,
-        "status": "exercise_started",
-        "exercise_name": normalized_name,
-    }
-
-
-def start_rest(duration_seconds: int | None) -> dict[str, Any]:
-    """Start a mocked rest timer."""
-
-    duration = duration_seconds or 90
-    WORKOUT_STATE.update(
-        {
-            "resting": True,
-            "rest_duration_seconds": duration,
-        }
-    )
-    return {
-        "ok": True,
-        "status": "rest_started",
-        "duration_seconds": duration,
-    }
-
-
-def finish_workout() -> dict[str, Any]:
-    """Finish the mocked workout session."""
+            totals = _session_totals(client, session_id)
+            now = _now_iso()
+            client.table("workout_sessions").update(
+                {
+                    "status": "completed",
+                    "finished_at": now,
+                    "total_volume": totals["total_volume"],
+                    "total_sets": totals["total_sets"],
+                }
+            ).eq("id", session_id).execute()
+        except Exception as exc:  # pragma: no cover
+            return {
+                "ok": False,
+                "status": "supabase_error",
+                "message": f"Could not finish the session: {exc}",
+            }
+        return {"ok": True, "status": "finished", "session_id": session_id, **totals}
 
     WORKOUT_STATE.update(
         {
@@ -136,3 +192,186 @@ def finish_workout() -> dict[str, Any]:
         }
     )
     return {"ok": True, "status": "finished"}
+
+
+def _session_totals(client, session_id: str) -> dict[str, Any]:
+    logs = (
+        client.table("workout_exercise_logs")
+        .select("id")
+        .eq("session_id", session_id)
+        .execute()
+    )
+    log_ids = [row["id"] for row in (logs.data or [])]
+    if not log_ids:
+        return {"total_volume": 0, "total_sets": 0}
+
+    sets = (
+        client.table("workout_sets")
+        .select("reps,load_value")
+        .in_("exercise_log_id", log_ids)
+        .execute()
+    )
+    rows = sets.data or []
+    total_sets = len(rows)
+    total_volume = 0.0
+    for row in rows:
+        reps = row.get("reps") or 0
+        load = row.get("load_value") or 0
+        try:
+            total_volume += float(reps) * float(load)
+        except (TypeError, ValueError):
+            continue
+    return {"total_volume": round(total_volume, 2), "total_sets": total_sets}
+
+
+# ---------------------------------------------------------------------------
+# Exercise + set logging
+# ---------------------------------------------------------------------------
+
+
+def _find_or_create_exercise_log(client, session_id: str, exercise_name: str) -> dict[str, Any]:
+    existing = (
+        client.table("workout_exercise_logs")
+        .select("id,exercise_number")
+        .eq("session_id", session_id)
+        .ilike("exercise_name", exercise_name)
+        .limit(1)
+        .execute()
+    )
+    rows = existing.data or []
+    if rows:
+        return rows[0]
+
+    count = (
+        client.table("workout_exercise_logs")
+        .select("exercise_number", count="exact")
+        .eq("session_id", session_id)
+        .execute()
+    )
+    next_number = (count.count or 0) + 1
+
+    created = (
+        client.table("workout_exercise_logs")
+        .insert(
+            {
+                "session_id": session_id,
+                "exercise_number": next_number,
+                "exercise_name": exercise_name,
+            }
+        )
+        .execute()
+    )
+    log_rows = created.data or []
+    if not log_rows:
+        raise RuntimeError("workout_exercise_logs insert returned no row")
+    return log_rows[0]
+
+
+def start_exercise(
+    exercise_name: str | None, *, context: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    normalized_name = normalize_exercise_name(exercise_name)
+    if not normalized_name:
+        return {
+            "ok": False,
+            "status": "missing_exercise",
+            "message": "Which exercise should I start?",
+        }
+
+    client, user_id = _get_supabase(context)
+    if client is not None and user_id is not None:
+        try:
+            session_id = _find_active_session_id(client, user_id) or _create_session(client, user_id)
+            _find_or_create_exercise_log(client, session_id, normalized_name)
+        except Exception as exc:  # pragma: no cover
+            return {
+                "ok": False,
+                "status": "supabase_error",
+                "message": f"Could not start exercise: {exc}",
+            }
+        return {
+            "ok": True,
+            "status": "exercise_started",
+            "exercise_name": normalized_name,
+            "session_id": session_id,
+        }
+
+    WORKOUT_STATE.update(
+        {
+            "active": True,
+            "current_exercise": normalized_name,
+            "resting": False,
+            "rest_duration_seconds": None,
+        }
+    )
+    return {"ok": True, "status": "exercise_started", "exercise_name": normalized_name}
+
+
+def log_set(
+    exercise_name: str | None,
+    reps: int | None,
+    weight: float | None,
+    *,
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_name = normalize_exercise_name(exercise_name)
+    if not normalized_name or reps is None or weight is None:
+        return {
+            "ok": False,
+            "status": "missing_fields",
+            "message": "To log a set, I need the exercise, reps, and weight.",
+        }
+
+    client, user_id = _get_supabase(context)
+    if client is not None and user_id is not None:
+        try:
+            session_id = _find_active_session_id(client, user_id) or _create_session(client, user_id)
+            log = _find_or_create_exercise_log(client, session_id, normalized_name)
+            set_count = (
+                client.table("workout_sets")
+                .select("set_number", count="exact")
+                .eq("exercise_log_id", log["id"])
+                .execute()
+            )
+            next_set_number = (set_count.count or 0) + 1
+
+            client.table("workout_sets").insert(
+                {
+                    "exercise_log_id": log["id"],
+                    "set_number": next_set_number,
+                    "reps": reps,
+                    "load_value": float(weight),
+                    "load_unit": "lb",
+                    "status": "manual",
+                    "completed_at": _now_iso(),
+                }
+            ).execute()
+        except Exception as exc:  # pragma: no cover
+            return {
+                "ok": False,
+                "status": "supabase_error",
+                "message": f"Could not log the set: {exc}",
+            }
+        return {
+            "ok": True,
+            "status": "logged",
+            "exercise_name": normalized_name,
+            "reps": reps,
+            "weight": weight,
+            "session_id": session_id,
+            "set_number": next_set_number,
+        }
+
+    logged_set = {"exercise_name": normalized_name, "reps": reps, "weight": weight}
+    LOGGED_SETS.append(logged_set)
+    return {"ok": True, "status": "logged", **logged_set}
+
+
+def start_rest(
+    duration_seconds: int | None, *, context: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Rest is a UI/timer concept — no Supabase write needed."""
+
+    duration = duration_seconds or 90
+    WORKOUT_STATE.update({"resting": True, "rest_duration_seconds": duration})
+    return {"ok": True, "status": "rest_started", "duration_seconds": duration}


### PR DESCRIPTION
## Summary

End-to-end iPhone-mode voice coach: speak "log a set: 5 reps at 135 on bench" into the native TrainAR app and the set is written to Supabase under your `auth.uid()` and shows up in the History tab.

Three independently-reviewable commits cover the three slices:

- **(A) Backend** — `src/assistant/supabase_client.py` builds a per-request Supabase client scoped to the caller's JWT. Flask `/api/assistant/chat` parses `Authorization: Bearer`, decodes the user id, and threads both into the assistant context. `src/assistant/tools.py` is rewritten so each tool (`start_workout`, `start_exercise`, `log_set`, `finish_workout`, `get_pr`) writes/reads the real tables when a client is in context. The in-memory `mock_db` path stays as a no-context fallback so existing pytest paths still work.
- **(B) iOS web** — `ios/assistant.js` now calls `supabase.auth.getSession()` and forwards the access token as a Bearer header. A new floating `CoachMicFab` in `ios/screens-main.jsx` asks the native bridge to start listening (and falls back to a `prompt()` box in a plain browser). `ios/app.jsx` subscribes to `trainar:history-changed` so the UI reloads from Supabase after a tool action.
- **(C) Native iOS shell** — new `AppleVoiceBridge` (SwiftUI + `SFSpeechRecognizer` + `AVSpeechSynthesizer`) conforming to the existing `GlassesBridge` protocol. `TrainARWebView` is now generic over `B: GlassesBridge` so the shell can swap mock/real bridges without duplicating WKWebView plumbing. The bootstrap script forwards `trainar:speak` events back to the native side. `Info.plist` gets `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription`.

The Meta DAT SDK is intentionally **not** added in this branch — that's a follow-up. iPhone-mode is the "physical device" here, with VisionClaw kept as reference only.

## Test plan

See [`docs/voice-coach-demo.md`](docs/voice-coach-demo.md) for the full walkthrough.

- [ ] Set `SUPABASE_URL` and `SUPABASE_ANON_KEY` in `.env`.
- [ ] `pip install -e .` (picks up new `supabase` + `PyJWT` deps).
- [ ] `python -m src.main --demo --port 5002`.
- [ ] In Xcode, build + run TrainAR on a simulator or device.
- [ ] Sign in. Tap the mic FAB on the Train tab. Allow mic + speech permissions.
- [ ] Say "log a set: 5 reps at 135 on bench." Confirm the coach speaks back, the History tab shows today's session with bench press 5×135, and Supabase Studio shows new rows in `workout_sessions` / `workout_exercise_logs` / `workout_sets` under your `auth.uid()`.
- [ ] Browser-only smoke (no Xcode): open `http://127.0.0.1:5002/ios/`, sign in, click the mic button, type a command into the prompt — same Supabase write path runs.

Verified locally: `xcodebuild -project native-ios/TrainAR/TrainAR.xcodeproj -scheme TrainAR -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)