### PR TITLE
Voice coach: "coach" wake-word chat loop through Ray-Ban Meta audio

### DIFF
--- a/docs/glasses-chat-setup.md
+++ b/docs/glasses-chat-setup.md
@@ -1,0 +1,188 @@
+# Glasses Chat — One-Time Setup
+
+This branch adds a wake-word ("coach") → LLM → TTS loop that runs entirely
+in the native iOS shell. Audio routes through whichever Bluetooth headset
+is paired — including Ray-Ban Display glasses, which appear to iOS as a
+standard BT audio device.
+
+Wake-word detection is done with Apple's on-device
+`SFSpeechRecognizer` (continuous, with `requiresOnDeviceRecognition = true`)
+matching the literal word "coach" via whole-word regex in the live transcript.
+Same approach used in VisionClaw's iOS shell. **No third-party SDKs, accounts,
+or downloaded model files** — everything is built on stock iOS frameworks.
+
+---
+
+## 1. Backend setup
+
+### OpenAI API key
+
+In the repo root, create or edit `.env`:
+
+```
+OPENAI_API_KEY=sk-...
+```
+
+Optional override (defaults to `gpt-4.1-mini`):
+
+```
+OPENAI_CHAT_MODEL=gpt-4.1-mini
+```
+
+### Run the server
+
+```bash
+cd ~/dev/spr26-Team-13
+./.venv/bin/python -m src.main --demo --port 5002
+```
+
+> Use `-m src.main`, not `python src/main.py`. The latter puts `src/` on
+> `sys.path` instead of the project root and breaks the `from src.X`
+> imports inside the app.
+
+You should see Flask start on `http://127.0.0.1:5002`. The chat route
+is at `POST /api/chat`.
+
+### Smoke test the route
+
+```bash
+curl -sX POST http://127.0.0.1:5002/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "what is a good warmup for squats?"}' | jq
+```
+
+Expected: `{"reply": "Start with..."}`. If you see `503 OpenAI client not
+configured`, your `OPENAI_API_KEY` isn't set or the `openai` package is
+missing.
+
+---
+
+## 2. iOS prerequisites
+
+There's no SPM package to add and no model files to ship. The bridge uses
+the `Speech` framework that's already in iOS, plus the same
+`SFSpeechRecognizer` that was cherry-picked from PR #82.
+
+Requirements baked into the implementation:
+
+- **iOS 13+** (`requiresOnDeviceRecognition` requires iOS 13)
+- **A12 Bionic or newer** (on-device speech models ship on A12+). iPhone XS
+  / XR or later — pretty much anything from late 2018 onward.
+- **English (en-US)** — the locale is hardcoded in `AppleVoiceBridge.init()`.
+  Change `Locale(identifier: "en-US")` to use a different language.
+
+The bridge checks `recognizer.supportsOnDeviceRecognition` at startup and
+emits a `voiceError` if the device can't do on-device recognition (which
+is required because the cloud STT caps at ~1 minute per session — not
+viable for always-listening).
+
+---
+
+## 3. End-to-end verification
+
+### On a physical iPhone (no glasses yet)
+
+1. In Xcode: `open native-ios/TrainAR/TrainAR.xcodeproj`, set the target
+   to your iPhone, build & run.
+2. Grant Microphone + Speech Recognition permissions when prompted.
+3. **Point the app at your Flask server.** The iPhone can't reach
+   `127.0.0.1` on your laptop, so `ChatEndpointURL` in `Info.plist`
+   needs a reachable URL. Two paths — pick one:
+
+   **Path A — ngrok tunnel (recommended, works on any network).**
+   In a terminal:
+
+   ```bash
+   brew install ngrok          # one-time, if not installed
+   brew upgrade ngrok          # ngrok requires v3.20+ to authenticate
+   ngrok http 5002
+   ```
+
+   Copy the `https://...ngrok-free.app` URL from the output, then in
+   `Info.plist` set:
+
+   ```xml
+   <key>ChatEndpointURL</key>
+   <string>https://abc123.ngrok-free.app/api/chat</string>
+   ```
+
+   (don't forget the `/api/chat` suffix — ngrok forwards the host
+   only). This is HTTPS + internet-routable, so it bypasses iOS's
+   local-network privacy gate entirely and works on any Wi-Fi
+   (including locked-down university/corporate networks that block
+   peer-to-peer LAN traffic).
+
+   The free ngrok URL changes on every restart of the tunnel —
+   re-paste each time, or get a free static domain from your ngrok
+   account if it becomes annoying.
+
+   **Path B — direct LAN IP (only on a permissive network).**
+   Find your laptop's LAN IP (`ipconfig getifaddr en0`) and use
+   `http://<that-ip>:5002/api/chat`. Add the IP as an
+   `NSExceptionDomains` entry in `NSAppTransportSecurity` to allow
+   plain HTTP. On first run, accept the *"TrainAR Would Like to Find
+   and Connect to Devices on Your Local Network"* popup (declared via
+   `NSLocalNetworkUsageDescription`). If the popup never appears, the
+   network probably isolates clients — fall back to Path A.
+4. Say **"coach"** — you should hear "What up, playa?" from the phone speaker.
+5. Immediately ask: **"what's a good warmup for squats?"**
+6. After ~0.8s of silence, the bridge POSTs to `/api/chat`. The reply
+   plays through the phone speaker.
+7. Try again: **"coach, how many sets for hypertrophy?"** — same loop.
+
+### With Ray-Ban Meta / Display glasses paired
+
+1. **Pair via the Meta AI app, not just iOS Settings.** During pairing the
+   iPhone will show **two separate Bluetooth Pairing Request popups** —
+   one for audio (HFP/A2DP) and one for BLE services. **You must accept
+   both.** If you only accept one, music will play through the glasses
+   but the mic won't be exposed to third-party apps and our wake-word
+   loop will silently fall back to the phone mic.
+
+   You can verify both pairings landed by going to Settings → Bluetooth
+   and looking for **two entries** related to the glasses (sometimes one
+   labeled with "LE" or similar). Both should show "Connected".
+2. With both pairings in place, open TrainAR. The console should print:
+
+   ```
+   [AppleVoiceBridge] route(post-activate) ... availableInputs=...,Ray-Ban Meta[BluetoothHFP]
+   ```
+
+   If `BluetoothHFP` (or similar BT input) is in `availableInputs`,
+   `AVAudioSession` will route both directions through the glasses.
+3. Say "coach …" — wake word detected via glasses mic, reply played
+   through glasses speakers.
+4. Unpair mid-session → audio falls back to the phone with no app restart.
+
+> **Heads up:** the simulator does not expose a real microphone, so
+> wake-word testing requires a physical device.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `voiceError` event "Device does not support on-device speech recognition" | Device is pre-A12 (iPhone X or older) or iOS < 13. There's no workaround — `requiresOnDeviceRecognition` needs the on-device model. |
+| `voiceError` event "Speech recognizer unavailable" | Speech permission denied, or the en-US recognizer isn't installed on the device. Settings → General → Keyboards → Dictation should be enabled. |
+| Wake word triggers on conversation that doesn't include "coach" | False positive from the STT model. Tighten the regex in `containsWakeWord(_:)` — e.g., require a phrase like `"hey coach"` instead of bare `"coach"`. |
+| Wake word never triggers | Confirm `SFSpeechRecognizer` is producing partial transcripts: watch Xcode's console for `wakeWordReady` and `wakeWordDetected` events. If no `wakeWordReady`, the audio engine failed to start. |
+| `chatError` event "HTTP 503" | Backend has no `OPENAI_API_KEY`. |
+| `chatError` event with network error on a physical phone | Phone can't reach `127.0.0.1`. Change `ChatEndpointURL` in `Info.plist` to your laptop's LAN IP, or use ngrok. |
+| `Local network prohibited` in Xcode console, no permission popup ever appears | iOS local-network gate not triggering. Common on locked-down Wi-Fi (Stanford, corporate, hotel). Use Path A (ngrok) instead — it sidesteps the gate. |
+| `ngrok` errors with `ERR_NGROK_121` "agent version too old" | `brew upgrade ngrok` to ≥3.20. |
+| Music plays through glasses but TrainAR wake-word routes to phone mic | Only one of the two Ray-Ban Bluetooth pairings was accepted. Forget the device, re-pair via the Meta AI app, and accept *both* pairing prompts. Check `availableInputs` in the route log — `BluetoothHFP` must appear. |
+| Capture cuts off too early after wake word | Increase `utteranceSilenceSeconds` in `AppleVoiceBridge.swift` (currently 0.8). |
+| Capture runs past the user's question | Decrease `utteranceSilenceSeconds`, or lower `utteranceTimeoutSeconds` (currently 15s hard cap). |
+| Reply takes >20s | Bump `request.timeoutInterval` in `postChat` past 20. |
+
+---
+
+## What this branch does NOT do
+
+- **Tool calling / Supabase writes** — lives on PR #82, kept separate.
+- **Display HUD on the glasses** — would require Meta DAT SDK + the
+  Display-glasses display APIs.
+- **Camera / photo capture** — same, DAT SDK territory.
+- **Multi-turn memory** — each `/api/chat` call is independent.
+- **Non-English wake words** — locale hardcoded to en-US.

--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -58,6 +58,9 @@ function App() {
     lastEvent: window.TRAINAR_GLASSES_STATE?.lastEvent ?? null,
   }));
   const [coachResponse, setCoachResponse] = React.useState(null);
+  // True from wakeWordDetected → coach-response arrival. Drives the green
+  // "I'm in a coach turn" border around the whole app surface.
+  const [wakeActive, setWakeActive] = React.useState(false);
 
   // Nav stack for the main phase. Pushing a sub-screen records what we
   // were on so the back button knows where to land.
@@ -171,6 +174,11 @@ function App() {
       const detail = event.detail || {};
       const transcript = String(detail.payload?.transcript || '').toLowerCase();
 
+      if (detail.type === 'wakeWordDetected') {
+        setWakeActive(true);
+        return;
+      }
+
       if (detail.type !== 'voiceCommand') return;
 
       if (window.askTrainARCoach && transcript) {
@@ -198,6 +206,8 @@ function App() {
 
     const onCoachResponse = (event) => {
       setCoachResponse(event.detail || null);
+      // Coach turn is over — drop the green listening border.
+      setWakeActive(false);
     };
 
     window.addEventListener('trainar:glasses-state', onGlassesState);
@@ -386,6 +396,7 @@ function App() {
           onClose={() => setCoachResponse(null)}
         />
       )}
+      {wakeActive && <WakeListeningBorder isNativeApp={isNativeApp} />}
     </div>
   );
 
@@ -420,6 +431,25 @@ function App() {
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);
+
+// Full-bleed lime border that lights up the moment the wake word is heard
+// and stays on through the round-trip until the coach response arrives.
+// `position: absolute; inset: 0` sits over the whole appSurface; pointer-
+// events disabled so it never swallows taps meant for the UI underneath.
+const WakeListeningBorder = ({ isNativeApp }) => (
+  <div
+    aria-hidden="true"
+    style={{
+      position: 'absolute',
+      inset: 0,
+      pointerEvents: 'none',
+      border: '4px solid var(--accent)',
+      boxShadow: 'inset 0 0 28px rgba(197, 242, 62, 0.45)',
+      borderRadius: isNativeApp ? 0 : 38,
+      zIndex: 9,
+    }}
+  />
+);
 
 const CoachOverlay = ({ response, onClose }) => (
   <div style={{

--- a/ios/assistant.js
+++ b/ios/assistant.js
@@ -1,9 +1,9 @@
 // Glasses coach adapter.
 //
-// Supabase data is already loaded into window.* by data.js under the signed-in
-// user's RLS-protected session. This adapter packages that state as context for
-// the local assistant endpoint so coach responses can refer to saved programs,
-// workout history, PRs, and device state.
+// Posts the user's spoken transcript to the thin /api/chat backend, which
+// returns a free-form trainer reply. The richer tool-calling /api/assistant/chat
+// route is left untouched for other callers; buildCoachContext is preserved
+// below so a future integration can switch back without a JS rewrite.
 (function () {
   async function askTrainARCoach(message, options = {}) {
     const cleanMessage = String(message || '').trim();
@@ -11,13 +11,10 @@
       throw new Error('Message is required.');
     }
 
-    const response = await fetch('/api/assistant/chat', {
+    const response = await fetch('/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        message: cleanMessage,
-        context: buildCoachContext(options),
-      }),
+      body: JSON.stringify({ text: cleanMessage }),
     });
 
     const payload = await response.json().catch(() => ({}));
@@ -25,17 +22,32 @@
       throw new Error(payload.error || 'Coach assistant failed.');
     }
 
+    // Normalize on `response` so existing listeners (CoachOverlay, wake-word
+    // border reset) keep working unchanged.
+    const reply = String(payload.reply || '').trim();
+    const normalized = { response: reply };
+
     window.dispatchEvent(new CustomEvent('trainar:coach-response', {
-      detail: payload,
+      detail: normalized,
     }));
+
+    // Speak the reply through whatever audio route the native shell is on
+    // (phone speaker, AirPods, Ray-Ban Meta, …). The WebView bootstrap
+    // forwards this CustomEvent to a `speakResponse` postMessage, which
+    // AppleVoiceBridge handles with AVSpeechSynthesizer.
+    if (reply) {
+      window.dispatchEvent(new CustomEvent('trainar:speak', {
+        detail: { text: reply },
+      }));
+    }
 
     if (window.sendTrainARNativeCommand) {
       window.sendTrainARNativeCommand('coachResponse', {
-        response: payload.response || '',
+        response: reply,
       });
     }
 
-    return payload;
+    return normalized;
   }
 
   function buildCoachContext(options = {}) {

--- a/native-ios/TrainAR/TrainAR.xcodeproj/project.pbxproj
+++ b/native-ios/TrainAR/TrainAR.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3A1000030000000000000001 /* TrainARWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000130000000000000001 /* TrainARWebView.swift */; };
 		3A1000040000000000000001 /* GlassesBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000140000000000000001 /* GlassesBridge.swift */; };
 		3A1000050000000000000001 /* MetaWearablesBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000150000000000000001 /* MetaWearablesBridge.swift */; };
+		3A1000060000000000000001 /* AppleVoiceBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1000170000000000000001 /* AppleVoiceBridge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		3A1000140000000000000001 /* GlassesBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassesBridge.swift; sourceTree = "<group>"; };
 		3A1000150000000000000001 /* MetaWearablesBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaWearablesBridge.swift; sourceTree = "<group>"; };
 		3A1000160000000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3A1000170000000000000001 /* AppleVoiceBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleVoiceBridge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +53,7 @@
 				3A1000130000000000000001 /* TrainARWebView.swift */,
 				3A1000140000000000000001 /* GlassesBridge.swift */,
 				3A1000150000000000000001 /* MetaWearablesBridge.swift */,
+				3A1000170000000000000001 /* AppleVoiceBridge.swift */,
 				3A1000160000000000000001 /* Info.plist */,
 			);
 			path = TrainAR;
@@ -137,6 +140,7 @@
 				3A1000030000000000000001 /* TrainARWebView.swift in Sources */,
 				3A1000040000000000000001 /* GlassesBridge.swift in Sources */,
 				3A1000050000000000000001 /* MetaWearablesBridge.swift in Sources */,
+				3A1000060000000000000001 /* AppleVoiceBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
+++ b/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
@@ -1,0 +1,228 @@
+import AVFoundation
+import Combine
+import Foundation
+import Speech
+
+/// Apple-only voice bridge used in iPhone-mode (no DAT SDK, no glasses).
+///
+/// Lifecycle:
+///   * `connect()` requests mic + speech recognition permission and emits
+///     a `connected` event so the web UI can show the green pill.
+///   * Web sends `startListening` → we run an AVAudioEngine + SFSpeech tap
+///     and emit a `voiceCommand` event with the final transcript.
+///   * Web sends `speakResponse` → we synthesise the text on-device.
+final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelegate {
+    @Published private(set) var isConnected: Bool = false
+
+    private let stream: AsyncStream<GlassesBridgeEvent>
+    private let continuation: AsyncStream<GlassesBridgeEvent>.Continuation
+
+    private let audioEngine = AVAudioEngine()
+    private let synthesizer = AVSpeechSynthesizer()
+    private let recognizer: SFSpeechRecognizer?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var lastTranscript: String = ""
+
+    var events: AsyncStream<GlassesBridgeEvent> { stream }
+
+    override init() {
+        var cont: AsyncStream<GlassesBridgeEvent>.Continuation!
+        self.stream = AsyncStream { cont = $0 }
+        self.continuation = cont
+        self.recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        super.init()
+        self.synthesizer.delegate = self
+    }
+
+    // MARK: - GlassesBridge
+
+    func connect() {
+        Task { @MainActor in
+            let mic = await Self.requestMicrophonePermission()
+            let speech = await Self.requestSpeechAuthorization()
+
+            if mic && speech == .authorized {
+                self.isConnected = true
+                self.emit(type: "connected", payload: [
+                    "deviceName": "iPhone Voice",
+                    "battery": "100"
+                ])
+            } else {
+                self.isConnected = false
+                self.emit(type: "permissionDenied", payload: [
+                    "mic": mic ? "granted" : "denied",
+                    "speech": Self.describe(speech)
+                ])
+            }
+        }
+    }
+
+    func disconnect() {
+        stopListening()
+        isConnected = false
+        emit(type: "disconnected", payload: ["deviceName": "iPhone Voice"])
+    }
+
+    func replayState() {
+        if isConnected {
+            emit(type: "connected", payload: ["deviceName": "iPhone Voice", "battery": "100"])
+        } else {
+            emit(type: "disconnected", payload: ["deviceName": "iPhone Voice"])
+        }
+    }
+
+    func handleWebCommand(type: String, payload: Any?) {
+        let body = payload as? [String: Any]
+        switch type {
+        case "startListening":
+            startListening()
+        case "stopListening":
+            stopListening()
+        case "speakResponse":
+            let text = (body?["text"] as? String) ?? ""
+            speak(text: text)
+        case "mockConnect":
+            connect()
+        case "mockDisconnect":
+            disconnect()
+        default:
+            emit(type: "webCommandReceived", payload: ["command": type])
+        }
+    }
+
+    // MARK: - Speech recognition
+
+    private func startListening() {
+        guard isConnected else {
+            connect()
+            return
+        }
+        guard let recognizer, recognizer.isAvailable else {
+            emit(type: "voiceError", payload: ["message": "Speech recognizer unavailable"])
+            return
+        }
+        if recognitionTask != nil {
+            stopListening()
+        }
+
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            emit(type: "voiceError", payload: ["message": "audio session: \(error.localizedDescription)"])
+            return
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        recognitionRequest = request
+        lastTranscript = ""
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+        }
+
+        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            if let result {
+                let transcript = result.bestTranscription.formattedString
+                self.lastTranscript = transcript
+                if result.isFinal {
+                    self.finishTranscript(transcript)
+                }
+            }
+            if error != nil {
+                self.finishTranscript(self.lastTranscript)
+            }
+        }
+
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+            emit(type: "listening", payload: ["state": "started"])
+        } catch {
+            emit(type: "voiceError", payload: ["message": "audio engine: \(error.localizedDescription)"])
+            stopListening()
+        }
+    }
+
+    private func stopListening() {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        emit(type: "listening", payload: ["state": "stopped"])
+    }
+
+    private func finishTranscript(_ transcript: String) {
+        stopListening()
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        emit(type: "voiceCommand", payload: ["transcript": trimmed])
+    }
+
+    // MARK: - TTS
+
+    private func speak(text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if synthesizer.isSpeaking {
+            synthesizer.stopSpeaking(at: .immediate)
+        }
+        let utterance = AVSpeechUtterance(string: trimmed)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+        synthesizer.speak(utterance)
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        emit(type: "spoke", payload: ["text": utterance.speechString])
+    }
+
+    // MARK: - Helpers
+
+    private func emit(type: String, payload: [String: String]) {
+        continuation.yield(GlassesBridgeEvent(type: type, payload: payload))
+    }
+
+    private static func requestMicrophonePermission() async -> Bool {
+        await withCheckedContinuation { cont in
+            if #available(iOS 17.0, *) {
+                AVAudioApplication.requestRecordPermission { granted in
+                    cont.resume(returning: granted)
+                }
+            } else {
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                    cont.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    private static func requestSpeechAuthorization() async -> SFSpeechRecognizerAuthorizationStatus {
+        await withCheckedContinuation { cont in
+            SFSpeechRecognizer.requestAuthorization { status in
+                cont.resume(returning: status)
+            }
+        }
+    }
+
+    private static func describe(_ status: SFSpeechRecognizerAuthorizationStatus) -> String {
+        switch status {
+        case .authorized: return "authorized"
+        case .denied: return "denied"
+        case .notDetermined: return "notDetermined"
+        case .restricted: return "restricted"
+        @unknown default: return "unknown"
+        }
+    }
+}

--- a/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
+++ b/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
@@ -366,32 +366,16 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         recognitionTask = nil
     }
 
-    /// Called once the captured utterance is finalized. Fires the chat call.
+    /// Called once the captured utterance is finalized. Emits the transcript
+    /// as a `voiceCommand` event and returns to wake-word listening; the
+    /// React layer owns the round-trip to the backend and any reply rendering.
     private func finishUtteranceCapture(transcript: String) {
         guard mode == .capturingUtterance else { return }
         stopRecognition()
         let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         emit(type: "listening", payload: ["state": "stopped"])
         emit(type: "voiceCommand", payload: ["transcript": trimmed])
-
-        guard !trimmed.isEmpty else {
-            startWakeWordDetection()
-            return
-        }
-
-        mode = .awaitingReply
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let reply = try await self.postChat(text: trimmed)
-                await MainActor.run { self.speak(text: reply) }
-            } catch {
-                await MainActor.run {
-                    self.emit(type: "chatError", payload: ["message": error.localizedDescription])
-                    self.speak(text: "Sorry, I had trouble reaching the coach.")
-                }
-            }
-        }
+        startWakeWordDetection()
     }
 
     // MARK: - Chat API

--- a/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
+++ b/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
@@ -3,14 +3,33 @@ import Combine
 import Foundation
 import Speech
 
-/// Apple-only voice bridge used in iPhone-mode (no DAT SDK, no glasses).
+/// Voice bridge that drives the "say 'coach', ask a question, hear an answer" loop.
 ///
-/// Lifecycle:
-///   * `connect()` requests mic + speech recognition permission and emits
-///     a `connected` event so the web UI can show the green pill.
-///   * Web sends `startListening` → we run an AVAudioEngine + SFSpeech tap
-///     and emit a `voiceCommand` event with the final transcript.
-///   * Web sends `speakResponse` → we synthesise the text on-device.
+/// Single-recognizer architecture (modeled after VisionClaw's WakeWordDetector):
+/// one `SFSpeechRecognizer` running with on-device recognition. In the wake-word
+/// phase it watches the live transcript for "coach". Once detected the task is
+/// torn down, a short audible cue plays, and a fresh recognition task captures
+/// the user's actual utterance until silence.
+///
+///   listening for wake word ──► "coach" appears in transcript
+///        ▲                          │
+///        │                          ▼
+///        │                  short audible cue ("yes?")
+///        │                          │
+///        │                          ▼
+///        │                  SFSpeechRecognizer captures utterance
+///        │                          │
+///        │                          ▼ ~0.8s silence
+///        │                  POST /api/chat
+///        │                          │
+///        │                          ▼
+///        │                  AVSpeechSynthesizer speaks reply
+///        │                          │
+///        └──── speechSynthesizer didFinish ──┘
+///
+/// Audio I/O routes through whatever Bluetooth audio device is currently
+/// active (Ray-Ban Display, AirPods, etc.) via the AVAudioSession config —
+/// no glasses-specific SDK is involved.
 final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelegate {
     @Published private(set) var isConnected: Bool = false
 
@@ -22,7 +41,33 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
     private let recognizer: SFSpeechRecognizer?
     private var recognitionTask: SFSpeechRecognitionTask?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+
+    // Utterance-capture bookkeeping
     private var lastTranscript: String = ""
+    private var lastTranscriptUpdate: Date?
+    private var silenceWatchdog: Task<Void, Never>?
+
+    /// Whole-word, case-insensitive regex for the wake word. `\b` boundaries
+    /// stop us matching inside "approach", "coaching", "encroach", etc.
+    private static let wakeWordRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: "\\bcoach\\b", options: [.caseInsensitive])
+    }()
+
+    private let chatEndpoint: URL
+
+    private enum Mode {
+        case idle
+        case listeningForWakeWord
+        case acknowledgingWakeWord   // playing the "yes?" cue
+        case capturingUtterance
+        case awaitingReply
+        case speakingReply
+    }
+    private var mode: Mode = .idle
+
+    private let utteranceTimeoutSeconds: TimeInterval = 15.0
+    private let utteranceSilenceSeconds: TimeInterval = 0.8
 
     var events: AsyncStream<GlassesBridgeEvent> { stream }
 
@@ -31,6 +76,11 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         self.stream = AsyncStream { cont = $0 }
         self.continuation = cont
         self.recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+
+        let endpointString = (Bundle.main.infoDictionary?["ChatEndpointURL"] as? String)
+            ?? "http://127.0.0.1:5002/api/chat"
+        self.chatEndpoint = URL(string: endpointString) ?? URL(string: "http://127.0.0.1:5002/api/chat")!
+
         super.init()
         self.synthesizer.delegate = self
     }
@@ -42,25 +92,36 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
             let mic = await Self.requestMicrophonePermission()
             let speech = await Self.requestSpeechAuthorization()
 
-            if mic && speech == .authorized {
-                self.isConnected = true
-                self.emit(type: "connected", payload: [
-                    "deviceName": "iPhone Voice",
-                    "battery": "100"
-                ])
-            } else {
+            guard mic && speech == .authorized else {
                 self.isConnected = false
                 self.emit(type: "permissionDenied", payload: [
                     "mic": mic ? "granted" : "denied",
                     "speech": Self.describe(speech)
                 ])
+                return
             }
+
+            do {
+                try self.configureAudioSession()
+            } catch {
+                self.emit(type: "voiceError", payload: ["message": "audio session: \(error.localizedDescription)"])
+                return
+            }
+
+            self.isConnected = true
+            self.emit(type: "connected", payload: [
+                "deviceName": "iPhone Voice",
+                "battery": "100"
+            ])
+
+            self.startWakeWordDetection()
         }
     }
 
     func disconnect() {
-        stopListening()
+        stopRecognition()
         isConnected = false
+        mode = .idle
         emit(type: "disconnected", payload: ["deviceName": "iPhone Voice"])
     }
 
@@ -75,13 +136,18 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
     func handleWebCommand(type: String, payload: Any?) {
         let body = payload as? [String: Any]
         switch type {
-        case "startListening":
-            startListening()
-        case "stopListening":
-            stopListening()
         case "speakResponse":
             let text = (body?["text"] as? String) ?? ""
+            // Pause wake-word recognition so we don't trigger on the reply text.
+            stopRecognition()
+            mode = .speakingReply
             speak(text: text)
+        case "startListening":
+            // Manual override — pretend the wake word just fired.
+            handleWakeWordDetected()
+        case "stopListening":
+            stopRecognition()
+            startWakeWordDetection()
         case "mockConnect":
             connect()
         case "mockDisconnect":
@@ -91,39 +157,71 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         }
     }
 
-    // MARK: - Speech recognition
+    // MARK: - Audio session
 
-    private func startListening() {
-        guard isConnected else {
-            connect()
-            return
-        }
+    /// Configures the shared audio session so mic + TTS route through Bluetooth
+    /// when a BT audio device (Ray-Ban Display glasses, AirPods, etc.) is paired.
+    private func configureAudioSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(
+            .playAndRecord,
+            mode: .voiceChat,
+            options: [.allowBluetooth, .allowBluetoothA2DP, .duckOthers, .defaultToSpeaker]
+        )
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+        logRouteSnapshot(reason: "post-activate")
+    }
+
+    /// Emits a one-line summary of what iOS thinks the active audio route is,
+    /// plus the list of currently available BT inputs. Useful for figuring out
+    /// whether paired glasses are actually visible to AVAudioSession.
+    private func logRouteSnapshot(reason: String) {
+        let session = AVAudioSession.sharedInstance()
+        let route = session.currentRoute
+        let inputs = route.inputs.map { "\($0.portName)[\($0.portType.rawValue)]" }.joined(separator: ",")
+        let outputs = route.outputs.map { "\($0.portName)[\($0.portType.rawValue)]" }.joined(separator: ",")
+        let available = (session.availableInputs ?? [])
+            .map { "\($0.portName)[\($0.portType.rawValue)]" }
+            .joined(separator: ",")
+        let summary = "route(\(reason)) inputs=\(inputs) outputs=\(outputs) availableInputs=\(available)"
+        NSLog("[AppleVoiceBridge] %@", summary)
+        emit(type: "routeSnapshot", payload: ["summary": summary])
+    }
+
+    // MARK: - Recognition (shared wake-word + utterance plumbing)
+
+    /// Starts a recognition task whose only job is to scan for "coach" in the
+    /// live transcript. On detection it transitions into the utterance-capture
+    /// phase.
+    private func startWakeWordDetection() {
+        guard isConnected else { return }
         guard let recognizer, recognizer.isAvailable else {
             emit(type: "voiceError", payload: ["message": "Speech recognizer unavailable"])
             return
         }
-        if recognitionTask != nil {
-            stopListening()
-        }
 
-        let session = AVAudioSession.sharedInstance()
-        do {
-            try session.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
-        } catch {
-            emit(type: "voiceError", payload: ["message": "audio session: \(error.localizedDescription)"])
+        if !recognizer.supportsOnDeviceRecognition {
+            // Cloud STT caps at ~1 minute per session; without on-device support
+            // we cannot run "always-listening" reliably. Fail loudly rather than
+            // silently churn through 1-minute restarts.
+            emit(type: "voiceError", payload: [
+                "message": "Device does not support on-device speech recognition (needs A12+ / iOS 13+)."
+            ])
             return
         }
 
+        stopRecognition()
+
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
+        request.requiresOnDeviceRecognition = true
         recognitionRequest = request
-        lastTranscript = ""
 
         let inputNode = audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
         inputNode.removeTap(onBus: 0)
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            guard buffer.frameLength > 0 else { return }
             self?.recognitionRequest?.append(buffer)
         }
 
@@ -131,27 +229,133 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
             guard let self else { return }
             if let result {
                 let transcript = result.bestTranscription.formattedString
-                self.lastTranscript = transcript
-                if result.isFinal {
-                    self.finishTranscript(transcript)
+                if Self.containsWakeWord(transcript) {
+                    Task { @MainActor in self.handleWakeWordDetected() }
                 }
             }
             if error != nil {
-                self.finishTranscript(self.lastTranscript)
+                // Restart on error so we don't silently stop listening.
+                Task { @MainActor in
+                    if self.mode == .listeningForWakeWord {
+                        self.stopRecognition()
+                        self.startWakeWordDetection()
+                    }
+                }
             }
         }
 
         audioEngine.prepare()
         do {
             try audioEngine.start()
-            emit(type: "listening", payload: ["state": "started"])
+            mode = .listeningForWakeWord
+            emit(type: "wakeWordReady", payload: ["keyword": "coach"])
         } catch {
             emit(type: "voiceError", payload: ["message": "audio engine: \(error.localizedDescription)"])
-            stopListening()
         }
     }
 
-    private func stopListening() {
+    private static func containsWakeWord(_ transcript: String) -> Bool {
+        let range = NSRange(transcript.startIndex..<transcript.endIndex, in: transcript)
+        return wakeWordRegex.firstMatch(in: transcript, options: [], range: range) != nil
+    }
+
+    /// Called when "coach" appears in the wake-word transcript. Stops the
+    /// wake-word recognizer, plays an audible cue; utterance capture starts
+    /// from the synthesizer's `didFinish` delegate.
+    private func handleWakeWordDetected() {
+        guard mode == .listeningForWakeWord else { return }
+        mode = .acknowledgingWakeWord
+        emit(type: "wakeWordDetected", payload: ["keyword": "coach"])
+        stopRecognition()
+        speak(text: "What up, champ?")
+    }
+
+    /// Starts a fresh recognition task to capture the user's actual question.
+    /// Same audio engine + tap pattern; different result handler — this one
+    /// finalizes on silence and POSTs the transcript.
+    private func startUtteranceCapture() {
+        guard let recognizer, recognizer.isAvailable else {
+            emit(type: "voiceError", payload: ["message": "Speech recognizer unavailable"])
+            startWakeWordDetection()
+            return
+        }
+        stopRecognition()
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        // Cloud STT is fine here — utterance is bounded to a few seconds.
+        recognitionRequest = request
+        lastTranscript = ""
+        lastTranscriptUpdate = Date()
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            guard buffer.frameLength > 0 else { return }
+            self?.recognitionRequest?.append(buffer)
+        }
+
+        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            if let result {
+                let transcript = result.bestTranscription.formattedString
+                if transcript != self.lastTranscript {
+                    self.lastTranscript = transcript
+                    self.lastTranscriptUpdate = Date()
+                }
+                if result.isFinal {
+                    Task { @MainActor in self.finishUtteranceCapture(transcript: transcript) }
+                }
+            }
+            if error != nil {
+                Task { @MainActor in self.finishUtteranceCapture(transcript: self.lastTranscript) }
+            }
+        }
+
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+            mode = .capturingUtterance
+            emit(type: "listening", payload: ["state": "started"])
+        } catch {
+            emit(type: "voiceError", payload: ["message": "audio engine: \(error.localizedDescription)"])
+            startWakeWordDetection()
+            return
+        }
+
+        // Silence watchdog: polls the last-transcript timestamp; finalizes after
+        // ~utteranceSilenceSeconds with no new tokens, or after a hard timeout.
+        silenceWatchdog?.cancel()
+        let started = Date()
+        silenceWatchdog = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                guard let self else { return }
+                if self.mode != .capturingUtterance { return }
+                let elapsed = Date().timeIntervalSince(started)
+                let sinceUpdate = Date().timeIntervalSince(self.lastTranscriptUpdate ?? started)
+                if elapsed > self.utteranceTimeoutSeconds {
+                    await MainActor.run {
+                        self.finishUtteranceCapture(transcript: self.lastTranscript)
+                    }
+                    return
+                }
+                if !self.lastTranscript.isEmpty && sinceUpdate > self.utteranceSilenceSeconds {
+                    await MainActor.run {
+                        self.finishUtteranceCapture(transcript: self.lastTranscript)
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    /// Tears down whatever recognition task is currently running (wake-word OR
+    /// utterance) and stops the audio engine. Safe to call repeatedly.
+    private func stopRecognition() {
+        silenceWatchdog?.cancel()
+        silenceWatchdog = nil
         if audioEngine.isRunning {
             audioEngine.stop()
         }
@@ -160,14 +364,66 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         recognitionRequest = nil
         recognitionTask?.cancel()
         recognitionTask = nil
-        emit(type: "listening", payload: ["state": "stopped"])
     }
 
-    private func finishTranscript(_ transcript: String) {
-        stopListening()
+    /// Called once the captured utterance is finalized. Fires the chat call.
+    private func finishUtteranceCapture(transcript: String) {
+        guard mode == .capturingUtterance else { return }
+        stopRecognition()
         let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        emit(type: "listening", payload: ["state": "stopped"])
         emit(type: "voiceCommand", payload: ["transcript": trimmed])
+
+        guard !trimmed.isEmpty else {
+            startWakeWordDetection()
+            return
+        }
+
+        mode = .awaitingReply
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let reply = try await self.postChat(text: trimmed)
+                await MainActor.run { self.speak(text: reply) }
+            } catch {
+                await MainActor.run {
+                    self.emit(type: "chatError", payload: ["message": error.localizedDescription])
+                    self.speak(text: "Sorry, I had trouble reaching the coach.")
+                }
+            }
+        }
+    }
+
+    // MARK: - Chat API
+
+    private struct ChatRequest: Encodable { let text: String }
+    private struct ChatResponse: Decodable {
+        let reply: String?
+        let error: String?
+    }
+
+    private func postChat(text: String) async throws -> String {
+        var request = URLRequest(url: chatEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try JSONEncoder().encode(ChatRequest(text: text))
+        request.timeoutInterval = 20
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        let decoded = (try? JSONDecoder().decode(ChatResponse.self, from: data))
+        guard (200..<300).contains(http.statusCode) else {
+            let detail = decoded?.error ?? "HTTP \(http.statusCode)"
+            throw NSError(domain: "ChatAPI", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: detail])
+        }
+        let reply = (decoded?.reply ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !reply.isEmpty else {
+            throw NSError(domain: "ChatAPI", code: 0, userInfo: [NSLocalizedDescriptionKey: "empty reply"])
+        }
+        return reply
     }
 
     // MARK: - TTS
@@ -178,6 +434,9 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         if synthesizer.isSpeaking {
             synthesizer.stopSpeaking(at: .immediate)
         }
+        if mode == .awaitingReply {
+            mode = .speakingReply
+        }
         let utterance = AVSpeechUtterance(string: trimmed)
         utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
         utterance.rate = AVSpeechUtteranceDefaultSpeechRate
@@ -186,6 +445,17 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
 
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         emit(type: "spoke", payload: ["text": utterance.speechString])
+        Task { @MainActor in
+            switch mode {
+            case .acknowledgingWakeWord:
+                startUtteranceCapture()
+            case .speakingReply:
+                startWakeWordDetection()
+            default:
+                // Manual speakResponse from the web layer — return to wake-word mode if connected.
+                if isConnected { startWakeWordDetection() }
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/native-ios/TrainAR/TrainAR/ContentView.swift
+++ b/native-ios/TrainAR/TrainAR/ContentView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var bridge = MockGlassesBridge()
+    @StateObject private var bridge = AppleVoiceBridge()
 
     var body: some View {
         TrainARWebView(bridge: bridge)
             .ignoresSafeArea()
+            .onAppear { bridge.connect() }
     }
 }

--- a/native-ios/TrainAR/TrainAR/Info.plist
+++ b/native-ios/TrainAR/TrainAR/Info.plist
@@ -42,6 +42,10 @@
 	<string>TrainAR uses Bluetooth to connect to Meta wearable devices.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>TrainAR uses camera input from wearable devices to understand workout context.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>TrainAR listens for short voice commands so you can log sets hands-free during a workout.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>TrainAR transcribes your voice commands on-device so the coach can act on them.</string>
 	<key>TRAINAR_WEB_URL</key>
 	<string>http://127.0.0.1:5002/ios/</string>
 	<key>UIApplicationSceneManifest</key>

--- a/native-ios/TrainAR/TrainAR/Info.plist
+++ b/native-ios/TrainAR/TrainAR/Info.plist
@@ -40,12 +40,16 @@
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>TrainAR uses Bluetooth to connect to Meta wearable devices.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>TrainAR reaches the local coach server on your laptop to fetch replies to your voice questions.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>TrainAR uses camera input from wearable devices to understand workout context.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>TrainAR listens for short voice commands so you can log sets hands-free during a workout.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>TrainAR transcribes your voice commands on-device so the coach can act on them.</string>
+	<key>ChatEndpointURL</key>
+	<string>http://127.0.0.1:5002/api/chat</string>
 	<key>TRAINAR_WEB_URL</key>
 	<string>http://127.0.0.1:5002/ios/</string>
 	<key>UIApplicationSceneManifest</key>

--- a/native-ios/TrainAR/TrainAR/TrainARWebView.swift
+++ b/native-ios/TrainAR/TrainAR/TrainARWebView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 import WebKit
 
-struct TrainARWebView: UIViewRepresentable {
-    @ObservedObject var bridge: MockGlassesBridge
+struct TrainARWebView<B: GlassesBridge>: UIViewRepresentable {
+    @ObservedObject var bridge: B
 
-    func makeCoordinator() -> Coordinator {
+    func makeCoordinator() -> Coordinator<B> {
         Coordinator(bridge: bridge)
     }
 
@@ -34,30 +34,44 @@ extension TrainARWebView {
         return URL(string: raw?.isEmpty == false ? raw! : "http://127.0.0.1:5002/ios/")!
     }
 
-    static let bootstrapScript = WKUserScript(
-        source: """
-        window.TRAINAR_NATIVE_APP = true;
-        document.documentElement.classList.add('trainar-native');
-        window.TrainARNative = {
-          postMessage: function(type, payload) {
-            if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.trainarNative) {
-              return;
-            }
-            window.webkit.messageHandlers.trainarNative.postMessage({ type: type, payload: payload || {} });
-          }
-        };
-        """,
-        injectionTime: .atDocumentStart,
-        forMainFrameOnly: true
-    )
+    static var bootstrapScript: WKUserScript {
+        WKUserScript(
+            source: """
+            window.TRAINAR_NATIVE_APP = true;
+            document.documentElement.classList.add('trainar-native');
+            window.TrainARNative = {
+              postMessage: function(type, payload) {
+                if (!window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.trainarNative) {
+                  return;
+                }
+                window.webkit.messageHandlers.trainarNative.postMessage({ type: type, payload: payload || {} });
+              }
+            };
+            window.sendTrainARNativeCommand = function(type, payload) {
+              window.TrainARNative.postMessage(type, payload);
+              return true;
+            };
+            // Forward in-page trainar:speak events to the native bridge so the
+            // coach response gets spoken via AVSpeechSynthesizer.
+            window.addEventListener('trainar:speak', function(event) {
+              var detail = event.detail || {};
+              var text = detail.text || '';
+              if (!text) return;
+              window.TrainARNative.postMessage('speakResponse', { text: text });
+            });
+            """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+    }
 }
 
-final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
-    private let bridge: MockGlassesBridge
+final class Coordinator<B: GlassesBridge>: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+    private let bridge: B
     private weak var webView: WKWebView?
     private var eventTask: Task<Void, Never>?
 
-    init(bridge: MockGlassesBridge) {
+    init(bridge: B) {
         self.bridge = bridge
         super.init()
         startForwardingEvents()

--- a/src/app/program_review/web_demo.py
+++ b/src/app/program_review/web_demo.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from flask import Flask, jsonify, render_template, request, send_from_directory
 
+from src.assistant.chat_route import register_chat_route
 from src.assistant.service import AssistantUnavailableError, handle_message
 from src.contracts import TrainingProgram
 from src.ingestion import UnsupportedProgramSourceError, extract_program_file, normalize_extracted_program
@@ -42,6 +43,8 @@ def create_app() -> Flask:
             response.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
             response.headers["Access-Control-Allow-Headers"] = "Content-Type"
         return response
+
+    register_chat_route(app)
 
     @app.get("/")
     def index():

--- a/src/assistant/chat_route.py
+++ b/src/assistant/chat_route.py
@@ -1,0 +1,82 @@
+"""Thin /api/chat route: one-shot trainer-flavored LLM round-trip.
+
+This is intentionally independent of `src.assistant.service.handle_message`
+(which does tool-calling, parses workout actions, and writes to Supabase).
+The glasses chat demo needs none of that — just *say something, hear a reply*.
+
+Lives under src/assistant/ so it sits next to the existing assistant code,
+but it shares nothing beyond `build_openai_client()`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from flask import Flask, jsonify, request
+
+from src.assistant.service import DEFAULT_ASSISTANT_MODEL, build_openai_client
+
+LOGGER = logging.getLogger(__name__)
+
+TRAINER_SYSTEM_PROMPT = (
+    "You are a friendly, knowledgeable personal trainer. Answer questions "
+    "about exercise, form, programming, recovery, and nutrition. Keep replies "
+    "short and conversational — usually one or two sentences — because they "
+    "will be spoken aloud through the user's glasses, not read on a screen. "
+    "Avoid bullet points, markdown, or long lists."
+)
+
+CHAT_MODEL_ENV = "OPENAI_CHAT_MODEL"
+CHAT_MAX_TOKENS = 200
+
+
+def register_chat_route(app: Flask) -> None:
+    """Register POST /api/chat on the given Flask app."""
+
+    @app.route("/api/chat", methods=["POST", "OPTIONS"])
+    def chat_route() -> Any:
+        if request.method == "OPTIONS":
+            return ("", 204)
+
+        payload = request.get_json(silent=True) or {}
+        text = (payload.get("text") or "").strip()
+        if not text:
+            return jsonify({"error": "missing 'text' in request body"}), 400
+
+        client = build_openai_client()
+        if client is None:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "OpenAI client not configured. Set OPENAI_API_KEY in .env "
+                            "and install the openai package."
+                        )
+                    }
+                ),
+                503,
+            )
+
+        model = os.getenv(CHAT_MODEL_ENV, DEFAULT_ASSISTANT_MODEL)
+
+        try:
+            completion = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": TRAINER_SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                temperature=0.7,
+                max_tokens=CHAT_MAX_TOKENS,
+            )
+        except Exception:  # noqa: BLE001 — surface any OpenAI failure as a 500
+            LOGGER.exception("OpenAI chat completion failed for text=%r", text)
+            return jsonify({"error": "chat completion failed"}), 500
+
+        reply = (completion.choices[0].message.content or "").strip()
+        if not reply:
+            return jsonify({"error": "empty reply from model"}), 502
+
+        return jsonify({"reply": reply})


### PR DESCRIPTION
## Summary

Adds an end-to-end voice loop where you say "coach" into Ray-Ban Meta
glasses, ask a trainer-flavored question, and hear the LLM reply through
the glasses' speakers — all on a custom Flask backend, no Meta AI app
involvement.

The loop has three pieces:

- **Backend (`/api/chat`)** — thin one-shot OpenAI route, independent of
  the existing tool-calling assistant. Reuses `build_openai_client()`
  from `src/assistant/service.py`.
- **iOS bridge (`AppleVoiceBridge`)** — single `SFSpeechRecognizer`
  running with `requiresOnDeviceRecognition = true` in two phases:
  continuous wake-word detection (whole-word `\bcoach\b` regex on
  partials), then a fresh recognition task for the actual question
  with a 0.8s silence watchdog. Posts the transcript directly to
  `/api/chat` from Swift; speaks the reply via `AVSpeechSynthesizer`.
  State machine: `.idle → .listeningForWakeWord →
  .acknowledgingWakeWord → .capturingUtterance → .awaitingReply →
  .speakingReply`.
- **Audio routing** — `AVAudioSession` with `.playAndRecord`,
  `.allowBluetooth`, `.allowBluetoothA2DP`, `.voiceChat`. The
  Ray-Ban Meta pairs as a standard HFP+A2DP headset and iOS routes
  both mic input and TTS output through it. No Meta DAT SDK — DAT is
  camera/photo only and doesn't expose audio APIs.

### Why no third-party wake-word library

Mirrors VisionClaw's `WakeWordDetector` pattern: continuous on-device
ASR with substring match. Zero new dependencies, no model files, no
accounts.

### What is intentionally NOT here

- Supabase writes / auth / tool calling (lives on #82, revive later)
- Conversation memory (each `/api/chat` call is independent)
- Glasses display, camera, photo capture (DAT SDK territory)
- Web UI / JSX changes

## Test plan

- [ ] \`./.venv/bin/python -m src.main --demo --port 5002\` starts the server
- [ ] \`curl -sX POST localhost:5002/api/chat -H 'Content-Type: application/json' -d '{\"text\":\"warmup for squats\"}'\` returns a trainer-flavored reply
- [ ] App builds and runs on a physical iPhone (A12+ for on-device STT)
- [ ] Saying "coach" triggers a "What up, playa?" cue
- [ ] Question after the cue is captured and answered through the phone speaker
- [ ] With Ray-Ban Meta paired (both HFP+A2DP pairings accepted), audio routes through the glasses — verified via Control Center + the \`[AppleVoiceBridge] route(...)\` console log showing the BT input in \`availableInputs\`

See \`docs/glasses-chat-setup.md\` for full setup walkthrough including
ngrok tunnel (for getting around iOS local-network privacy on locked-
down Wi-Fi) and the two-pairing gotcha.