### PR TITLE
Fix voice workout flows and HUD prep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
-LLM_NORMALIZER_PROVIDER=gemini
+LLM_NORMALIZER_PROVIDER=openai
 GEMINI_API_KEY=your_key_here
 GEMINI_NORMALIZER_MODEL=gemini-2.5-flash
 OPENAI_API_KEY=
-OPENAI_NORMALIZER_MODEL=gpt-4.1
+OPENAI_NORMALIZER_MODEL=gpt-4.1-mini
+OPENAI_ASSISTANT_MODEL=gpt-4.1-mini
+OPENAI_CHAT_MODEL=gpt-4.1-mini
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_or_publishable_key
 GROQ_API_KEY=
 GROQ_NORMALIZER_MODEL=openai/gpt-oss-120b

--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -134,6 +134,96 @@ function nameSimilarity(left, right) {
   return overlap / Math.max(leftSet.size, rightWords.length, 1);
 }
 
+function shouldAcknowledgeLongCoachTask(transcript) {
+  const text = normalizeCoachName(transcript);
+  return /\b(build|create|generate|make|write|program)\b/.test(text)
+    && /\b(workout|program|session)\b/.test(text);
+}
+
+function isAffirmativeCoachReply(transcript) {
+  const text = normalizeCoachName(transcript);
+  return /^(yes|yeah|yep|correct|right|confirm|do it|log it|that is right|that's right)\b/.test(text);
+}
+
+function isNegativeCoachReply(transcript) {
+  const text = normalizeCoachName(transcript);
+  return /^(no|nope|cancel|do not|don't|nevermind|never mind)\b/.test(text);
+}
+
+function buildPendingLogFromTranscript(transcript, { programId, sessionId, currentExerciseName }) {
+  if (!sessionId || !currentExerciseName) return null;
+  const text = normalizeCoachName(transcript);
+  if (!/\b(log|record|add|did|done|completed|finished)\b/.test(text)) return null;
+
+  const repsMatch = text.match(/\b(\d+)\s*(?:reps?|rep)?\b/);
+  const reps = repsMatch ? Number.parseInt(repsMatch[1], 10) : null;
+  if (!Number.isFinite(reps)) return null;
+
+  const weightMatch = text.match(/\b(?:at|with|for)\s+(\d+(?:\.\d+)?)\s*(?:lb|lbs|pounds?)?\b/);
+  const weight = weightMatch ? Number.parseFloat(weightMatch[1]) : null;
+  const requestedExercise = findMentionedProgramExercise(text, programId);
+  if (!requestedExercise) return null;
+  if (namesCloseEnough(requestedExercise.name, currentExerciseName)) return null;
+
+  return {
+    sessionId,
+    programId,
+    exerciseName: requestedExercise.name,
+    currentExerciseName,
+    reps,
+    weight: Number.isFinite(weight) ? weight : null,
+  };
+}
+
+function findMentionedProgramExercise(text, programId) {
+  const detail = window.getProgramDetail && programId ? window.getProgramDetail(programId) : window.PROGRAM_DETAIL;
+  const exercises = getAllProgramExercisesForCoach(detail);
+  let best = null;
+  let bestScore = 0;
+  exercises.forEach((exercise) => {
+    const name = normalizeCoachName(exercise.name || exercise.exercise_name);
+    if (!name) return;
+    const compactName = name.replace(/\s+/g, '');
+    const compactText = text.replace(/\s+/g, '');
+    const score = text.includes(name) || compactText.includes(compactName)
+      ? 1
+      : Math.max(nameSimilarity(text, name), compactSimilarity(compactText, compactName));
+    if (score > bestScore) {
+      best = exercise;
+      bestScore = score;
+    }
+  });
+  return bestScore >= 0.68 ? best : null;
+}
+
+function getAllProgramExercisesForCoach(detail) {
+  if (!detail) return [];
+  if (Array.isArray(detail.exercises) && detail.exercises.length) return detail.exercises;
+  return (detail.days || []).flatMap((day) =>
+    (day.blocks || []).flatMap((block) => block.exercises || []),
+  );
+}
+
+function namesCloseEnough(left, right) {
+  const leftName = normalizeCoachName(left);
+  const rightName = normalizeCoachName(right);
+  return leftName === rightName
+    || leftName.includes(rightName)
+    || rightName.includes(leftName)
+    || compactSimilarity(leftName.replace(/\s+/g, ''), rightName.replace(/\s+/g, '')) >= 0.8
+    || nameSimilarity(leftName, rightName) >= 0.68;
+}
+
+function compactSimilarity(left, right) {
+  if (!left || !right) return 0;
+  if (left === right || left.includes(right) || right.includes(left)) return 1;
+  const leftPairs = new Set(Array.from({ length: Math.max(left.length - 1, 0) }, (_, index) => left.slice(index, index + 2)));
+  const rightPairs = Array.from({ length: Math.max(right.length - 1, 0) }, (_, index) => right.slice(index, index + 2));
+  if (!leftPairs.size || !rightPairs.length) return 0;
+  const overlap = rightPairs.filter((pair) => leftPairs.has(pair)).length;
+  return overlap / Math.max(leftPairs.size, rightPairs.length, 1);
+}
+
 function App() {
   const auth = useAuth();
   const isNativeApp = Boolean(window.TRAINAR_NATIVE_APP);
@@ -158,13 +248,16 @@ function App() {
   const [activeSessionId, setActiveSessionId] = React.useState(null);
   const [activeWorkoutDay, setActiveWorkoutDay] = React.useState(null);
   const [activeWorkoutStep, setActiveWorkoutStep] = React.useState(null);
+  const [lastLoggedSet, setLastLoggedSet] = React.useState(null);
   const [activeRest, setActiveRest] = React.useState(null);
   const activeProgramIdRef = React.useRef(activeProgramId);
   const activeSessionIdRef = React.useRef(activeSessionId);
   const activeWorkoutDayRef = React.useRef(activeWorkoutDay);
   const activeWorkoutStepRef = React.useRef(activeWorkoutStep);
+  const lastLoggedSetRef = React.useRef(lastLoggedSet);
   const activeRestRef = React.useRef(activeRest);
   const loadedToGlassesRef = React.useRef(loadedToGlasses);
+  const pendingLogConfirmationRef = React.useRef(null);
   const coachTurnIdRef = React.useRef(0);
   const appliedCoachTurnIdRef = React.useRef(0);
   const [selectedProgramId, setSelectedProgramId] = React.useState(null);
@@ -205,9 +298,23 @@ function App() {
     activeSessionIdRef.current = activeSessionId;
     activeWorkoutDayRef.current = activeWorkoutDay;
     activeWorkoutStepRef.current = activeWorkoutStep;
+    lastLoggedSetRef.current = lastLoggedSet;
     activeRestRef.current = activeRest;
     loadedToGlassesRef.current = loadedToGlasses;
-  }, [activeProgramId, activeSessionId, activeWorkoutDay, activeWorkoutStep, activeRest, loadedToGlasses]);
+  }, [activeProgramId, activeSessionId, activeWorkoutDay, activeWorkoutStep, lastLoggedSet, activeRest, loadedToGlasses]);
+
+  React.useEffect(() => {
+    if (!window.buildTrainARHudStateSnapshot) return;
+    const hudState = window.buildTrainARHudStateSnapshot({
+      programId: activeProgramId,
+      day: activeWorkoutDay,
+      step: activeWorkoutStep,
+      rest: activeRest,
+      coachResponse,
+    });
+    window.TRAINAR_HUD_STATE = hudState;
+    window.dispatchEvent(new CustomEvent('trainar:hud-state', { detail: hudState }));
+  }, [activeProgramId, activeWorkoutDay, activeWorkoutStep, activeRest, coachResponse]);
 
   React.useEffect(() => {
     if (auth.pending) return;
@@ -259,12 +366,14 @@ function App() {
     activeSessionIdRef.current = null;
     activeWorkoutDayRef.current = null;
     activeWorkoutStepRef.current = null;
+    lastLoggedSetRef.current = null;
     activeRestRef.current = null;
     setLoadedToGlasses(false);
     setActiveProgramId(null);
     setActiveSessionId(null);
     setActiveWorkoutDay(null);
     setActiveWorkoutStep(null);
+    setLastLoggedSet(null);
     setActiveRest(null);
     setSelectedProgramId(null);
     setScreen('splash');
@@ -287,12 +396,14 @@ function App() {
     activeProgramIdRef.current = nextProgramId;
     activeWorkoutDayRef.current = nextDay;
     activeWorkoutStepRef.current = nextStep;
+    lastLoggedSetRef.current = null;
     activeRestRef.current = null;
     loadedToGlassesRef.current = true;
     setActiveProgramId(nextProgramId);
     setLoadedToGlasses(true);
     setActiveWorkoutDay(nextDay);
     setActiveWorkoutStep(nextStep);
+    setLastLoggedSet(null);
     setActiveRest(null);
     setScreen('running');
     setStack([]);
@@ -313,28 +424,42 @@ function App() {
     loadedToGlassesRef.current = false;
     activeWorkoutDayRef.current = null;
     activeWorkoutStepRef.current = null;
+    lastLoggedSetRef.current = null;
     activeRestRef.current = null;
     setLoadedToGlasses(false);
     setActiveWorkoutDay(null);
     setActiveWorkoutStep(null);
+    setLastLoggedSet(null);
     setActiveRest(null);
     if (window.finishWorkout && sessionIdToFinish) {
       try {
-        await window.finishWorkout(sessionIdToFinish, programIdToFinish);
+        const finishedSession = await window.finishWorkout(sessionIdToFinish, programIdToFinish);
+        if (finishedSession?.id && window.selectPastWorkout) {
+          const finishedWorkout = await window.selectPastWorkout(finishedSession.id);
+          setSelectedPastWorkout(finishedWorkout || window.PAST_WORKOUT || null);
+        } else {
+          setSelectedPastWorkout(window.PAST_WORKOUT || null);
+        }
       } catch (err) {
         console.error('Could not finish workout:', err);
+        setSelectedPastWorkout(window.PAST_WORKOUT || null);
       }
+    } else {
+      setSelectedPastWorkout(window.PAST_WORKOUT || null);
     }
     activeSessionIdRef.current = null;
     setActiveSessionId(null);
-    go('past');
+    setStack([]);
+    setScreen('past');
   };
 
   const advanceWorkoutStep = () => {
     const nextStep = nextStepForProgram(activeProgramIdRef.current, activeWorkoutStepRef.current, { day: activeWorkoutDayRef.current });
     activeWorkoutStepRef.current = nextStep;
+    lastLoggedSetRef.current = null;
     activeRestRef.current = null;
     setActiveWorkoutStep(nextStep);
+    setLastLoggedSet(null);
     setActiveRest(null);
   };
 
@@ -344,9 +469,16 @@ function App() {
       day: activeWorkoutDayRef.current,
     });
     activeWorkoutStepRef.current = nextStep;
+    lastLoggedSetRef.current = null;
     activeRestRef.current = null;
     setActiveWorkoutStep(nextStep);
+    setLastLoggedSet(null);
     setActiveRest(null);
+  };
+
+  const openHudDemo = () => {
+    setStack((prev) => [...prev, screen]);
+    setScreen('hud');
   };
 
   React.useEffect(() => {
@@ -365,9 +497,72 @@ function App() {
 
       if (detail.type !== 'voiceCommand') return;
 
+      const pendingLog = pendingLogConfirmationRef.current;
+      if (pendingLog && isAffirmativeCoachReply(transcript)) {
+        pendingLogConfirmationRef.current = null;
+        if (window.logWorkoutSet) {
+          window.logWorkoutSet(pendingLog.sessionId, {
+            exerciseName: pendingLog.exerciseName,
+            reps: pendingLog.reps,
+            weight: pendingLog.weight,
+            programId: pendingLog.programId,
+            currentExerciseName: activeWorkoutStepRef.current?.exerciseName,
+            allowOffCurrent: true,
+          }).then((result) => {
+            const logged = {
+              exerciseName: result?.exerciseLog?.exercise_name || pendingLog.exerciseName,
+              setNumber: result?.set?.set_number || null,
+              reps: result?.set?.reps ?? pendingLog.reps,
+              weight: result?.set?.load_value ?? pendingLog.weight,
+            };
+            lastLoggedSetRef.current = logged;
+            setLastLoggedSet(logged);
+            const response = `Logged ${logged.reps} reps of ${logged.exerciseName}${logged.weight != null ? ` at ${logged.weight} lb` : ''}.`;
+            setCoachResponse({ response });
+            setWakeActive(false);
+            window.dispatchEvent(new CustomEvent('trainar:speak', { detail: { text: response } }));
+          }).catch((err) => {
+            setCoachResponse({ response: err.message || 'Could not log that set.' });
+            setWakeActive(false);
+          });
+        }
+        return;
+      }
+
+      if (pendingLog && isNegativeCoachReply(transcript)) {
+        pendingLogConfirmationRef.current = null;
+        setCoachResponse({ response: 'Okay, I did not log it.' });
+        setWakeActive(false);
+        window.dispatchEvent(new CustomEvent('trainar:speak', { detail: { text: 'Okay, I did not log it.' } }));
+        return;
+      }
+
+      const pendingLogFromTranscript = buildPendingLogFromTranscript(transcript, {
+        programId: activeProgramIdRef.current,
+        sessionId: activeSessionIdRef.current,
+        currentExerciseName: activeWorkoutStepRef.current?.exerciseName,
+      });
+      if (pendingLogFromTranscript && window.logWorkoutSet) {
+        pendingLogConfirmationRef.current = pendingLogFromTranscript;
+        const response = `You are currently on ${pendingLogFromTranscript.currentExerciseName}. Did you mean to log ${pendingLogFromTranscript.exerciseName} instead?`;
+        setCoachResponse({ response, expectsFollowUp: true });
+        setWakeActive(true);
+        window.dispatchEvent(new CustomEvent('trainar:speak', {
+          detail: { text: response, continueListening: true },
+        }));
+        return;
+      }
+
       if (window.askTrainARCoach && transcript) {
         const clientTurnId = coachTurnIdRef.current + 1;
         coachTurnIdRef.current = clientTurnId;
+        if (shouldAcknowledgeLongCoachTask(transcript)) {
+          setWakeActive(true);
+          setCoachResponse({ response: 'Working on it.', processing: true });
+          window.dispatchEvent(new CustomEvent('trainar:speak', {
+            detail: { text: 'Working on it.' },
+          }));
+        }
         const currentProgramId = activeProgramIdRef.current;
         const currentSessionId = activeSessionIdRef.current;
         const currentDay = activeWorkoutDayRef.current;
@@ -386,6 +581,7 @@ function App() {
           } : null,
         }).catch((err) => {
           setCoachResponse({ response: err.message || 'Coach assistant failed.' });
+          setWakeActive(false);
         });
         return;
       }
@@ -401,9 +597,18 @@ function App() {
     };
 
     const onCoachResponse = (event) => {
-      setCoachResponse(event.detail || null);
-      // Coach turn is over — drop the green listening border.
-      setWakeActive(false);
+      const detail = event.detail || null;
+      if (detail?.actionResult?.needs_confirmation && detail.actionResult.requested_exercise) {
+        pendingLogConfirmationRef.current = {
+          sessionId: activeSessionIdRef.current,
+          programId: activeProgramIdRef.current,
+          exerciseName: detail.actionResult.requested_exercise,
+          reps: detail.actionResult.reps,
+          weight: detail.actionResult.weight,
+        };
+      }
+      setCoachResponse(detail);
+      setWakeActive(Boolean(detail?.expectsFollowUp));
     };
 
     const onCoachAction = async (event) => {
@@ -415,6 +620,10 @@ function App() {
 
       if (patch.type === 'program_created') {
         const programId = patch.programId || null;
+        let detail = null;
+        if (window.upsertTrainarProgramCache && (patch.program || patch.detail)) {
+          detail = window.upsertTrainarProgramCache(patch.program, patch.detail);
+        }
         if (auth.user && window.loadTrainarData) {
           try {
             await window.loadTrainarData(auth.user.id);
@@ -423,9 +632,12 @@ function App() {
           }
         }
         if (programId) {
-          const detail = window.getProgramDetail ? window.getProgramDetail(programId) : null;
+          if (window.upsertTrainarProgramCache && (patch.program || patch.detail)) {
+            detail = window.upsertTrainarProgramCache(patch.program, patch.detail) || detail;
+          }
+          detail = detail || (window.getProgramDetail ? window.getProgramDetail(programId) : null);
           setSelectedProgramId(programId);
-          setParsedProgram(detail || window.PROGRAM_DETAIL || null);
+          setParsedProgram(detail || patch.detail || null);
           setStack((prev) => [...prev, 'home']);
           setScreen('detail');
         }
@@ -433,6 +645,9 @@ function App() {
       }
 
       if (patch.type === 'workout_started') {
+        if (window.upsertTrainarProgramCache && (patch.program || patch.detail)) {
+          window.upsertTrainarProgramCache(patch.program, patch.detail);
+        }
         const nextDay = patch.day || resolveWorkoutDay(patch.programId || activeProgramId, null);
         const nextProgramId = patch.programId || activeProgramId;
         const nextStep = patch.step || nextStepForProgram(nextProgramId, null, { day: nextDay });
@@ -440,12 +655,14 @@ function App() {
         activeSessionIdRef.current = patch.sessionId || null;
         activeWorkoutDayRef.current = nextDay;
         activeWorkoutStepRef.current = nextStep;
+        lastLoggedSetRef.current = null;
         activeRestRef.current = null;
         loadedToGlassesRef.current = true;
         setActiveProgramId(nextProgramId);
         setActiveSessionId(patch.sessionId || null);
         setActiveWorkoutDay(nextDay);
         setActiveWorkoutStep(nextStep);
+        setLastLoggedSet(null);
         setActiveRest(null);
         setLoadedToGlasses(true);
         setScreen('running');
@@ -461,16 +678,20 @@ function App() {
         activeSessionIdRef.current = null;
         activeWorkoutDayRef.current = null;
         activeWorkoutStepRef.current = null;
+        lastLoggedSetRef.current = null;
         activeRestRef.current = null;
         setLoadedToGlasses(false);
         setActiveSessionId(null);
         setActiveWorkoutDay(null);
         setActiveWorkoutStep(null);
+        setLastLoggedSet(null);
         setActiveRest(null);
         if (auth.user && window.loadTrainarData) {
           window.loadTrainarData(auth.user.id).catch((err) => console.error('Could not refresh TrainAR data:', err));
         }
-        go('past');
+        setSelectedPastWorkout(window.PAST_WORKOUT || null);
+        setStack([]);
+        setScreen('past');
         return;
       }
 
@@ -480,6 +701,10 @@ function App() {
           activeRestRef.current = null;
           setActiveWorkoutStep(patch.step || null);
           setActiveRest(null);
+        }
+        if (patch.loggedSet) {
+          lastLoggedSetRef.current = patch.loggedSet;
+          setLastLoggedSet(patch.loggedSet);
         }
         if (auth.user && window.loadTrainarData) {
           window.loadTrainarData(auth.user.id).catch((err) => console.error('Could not refresh TrainAR data:', err));
@@ -504,6 +729,17 @@ function App() {
           exerciseName: patch.exerciseName,
           reps: patch.reps,
           weight: patch.weight,
+          programId: activeProgramIdRef.current,
+          currentExerciseName: activeWorkoutStepRef.current?.exerciseName,
+        }).then((result) => {
+          const logged = {
+            exerciseName: result?.exerciseLog?.exercise_name || patch.exerciseName || activeWorkoutStepRef.current?.exerciseName,
+            setNumber: result?.set?.set_number || null,
+            reps: result?.set?.reps ?? patch.reps,
+            weight: result?.set?.load_value ?? patch.weight,
+          };
+          lastLoggedSetRef.current = logged;
+          setLastLoggedSet(logged);
         }).catch((err) => {
           setCoachResponse({ response: err.message || 'Could not log that set.' });
         });
@@ -512,8 +748,10 @@ function App() {
 
       if (patch.type === 'exercise_started' || patch.type === 'workout_step_updated') {
         activeWorkoutStepRef.current = patch.step || null;
+        lastLoggedSetRef.current = null;
         activeRestRef.current = null;
         setActiveWorkoutStep(patch.step || null);
+        setLastLoggedSet(null);
         setActiveRest(null);
         if (patch.step) setScreen('running');
         return;
@@ -526,11 +764,13 @@ function App() {
         };
         activeRestRef.current = nextRest;
         if (patch.step) activeWorkoutStepRef.current = patch.step;
+        if (patch.step) lastLoggedSetRef.current = null;
         setActiveRest({
           durationSeconds: nextRest.durationSeconds,
           startedAt: nextRest.startedAt,
         });
         if (patch.step) setActiveWorkoutStep(patch.step);
+        if (patch.step) setLastLoggedSet(null);
         return;
       }
 
@@ -556,8 +796,10 @@ function App() {
           setCount: activeWorkoutStepRef.current?.setCount || 1,
         };
         activeWorkoutStepRef.current = nextStep;
+        lastLoggedSetRef.current = null;
         activeRestRef.current = null;
         setActiveWorkoutStep(nextStep);
+        setLastLoggedSet(null);
         setActiveRest(null);
         setScreen('running');
         return;
@@ -668,11 +910,24 @@ function App() {
         sessionId={activeSessionId}
         day={activeWorkoutDay}
         step={activeWorkoutStep}
+        lastLoggedSet={lastLoggedSet}
         rest={activeRest}
         onClose={() => switchTab('home')}
+        onOpenHud={openHudDemo}
         onFinish={finishWorkout}
         onNextSet={advanceWorkoutStep}
         onSkipExercise={skipWorkoutExercise}
+      />
+    ),
+
+    hud: (
+      <HudDemoScreen
+        programId={activeProgramId}
+        day={activeWorkoutDay}
+        step={activeWorkoutStep}
+        rest={activeRest}
+        coachResponse={coachResponse}
+        onClose={back}
       />
     ),
 
@@ -749,10 +1004,12 @@ function App() {
         onClose={back}
         onStartWorkout={() => startWorkout(selectedProgramId || parsedProgram?.programId)}
         onFinishWorkout={finishWorkout}
-        onDiscard={() => {
-          if (window.archiveProgram && selectedProgramId) {
-            window.archiveProgram(selectedProgramId).catch((err) => console.error('Could not archive program:', err));
-          }
+        onDiscard={async () => {
+          const programId = selectedProgramId || parsedProgram?.programId || null;
+          if (!window.archiveProgram) throw new Error('Program discard is not available.');
+          await window.archiveProgram(programId);
+          setSelectedProgramId(null);
+          setParsedProgram(window.PROGRAM_DETAIL || null);
           setStack([]);
           setScreen('home');
           setActiveTab('home');
@@ -779,7 +1036,7 @@ function App() {
       {showTabBar && (
         <TabBar active={activeTab} live={loadedToGlasses} onTab={switchTab} />
       )}
-      {coachResponse?.response && (
+      {screen !== 'hud' && coachResponse?.response && (
         <CoachOverlay
           response={coachResponse.response}
           onClose={() => setCoachResponse(null)}

--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -1,7 +1,7 @@
 // App — wires every screen into the iPhone frame.
 //
 // State machine (high level):
-//   signup phase: splash → auth → name → pair → home
+//   signup phase: splash → auth → name → training → home
 //   main phase:   tab roots (home / calendar / profile) + a small nav stack
 //                 for sub-screens (add a program flow, program detail, past
 //                 workout summary)
@@ -21,7 +21,7 @@ const SCREENS_WITH_TABBAR = TAB_ROOTS;
 
 // All known screens. If a screen isn't a tab root, hitting back pops it
 // off the stack to whatever was underneath.
-const SIGNUP_SCREENS = ['splash', 'auth', 'name', 'pair'];
+const SIGNUP_SCREENS = ['splash', 'auth', 'name', 'training'];
 
 function firstWorkoutStep(programId, day = null) {
   const detail = window.getProgramDetail && programId ? window.getProgramDetail(programId) : window.PROGRAM_DETAIL;
@@ -140,90 +140,6 @@ function shouldAcknowledgeLongCoachTask(transcript) {
     && /\b(workout|program|session)\b/.test(text);
 }
 
-function isAffirmativeCoachReply(transcript) {
-  const text = normalizeCoachName(transcript);
-  return /^(yes|yeah|yep|correct|right|confirm|do it|log it|that is right|that's right)\b/.test(text);
-}
-
-function isNegativeCoachReply(transcript) {
-  const text = normalizeCoachName(transcript);
-  return /^(no|nope|cancel|do not|don't|nevermind|never mind)\b/.test(text);
-}
-
-function buildPendingLogFromTranscript(transcript, { programId, sessionId, currentExerciseName }) {
-  if (!sessionId || !currentExerciseName) return null;
-  const text = normalizeCoachName(transcript);
-  if (!/\b(log|record|add|did|done|completed|finished)\b/.test(text)) return null;
-
-  const repsMatch = text.match(/\b(\d+)\s*(?:reps?|rep)?\b/);
-  const reps = repsMatch ? Number.parseInt(repsMatch[1], 10) : null;
-  if (!Number.isFinite(reps)) return null;
-
-  const weightMatch = text.match(/\b(?:at|with|for)\s+(\d+(?:\.\d+)?)\s*(?:lb|lbs|pounds?)?\b/);
-  const weight = weightMatch ? Number.parseFloat(weightMatch[1]) : null;
-  const requestedExercise = findMentionedProgramExercise(text, programId);
-  if (!requestedExercise) return null;
-  if (namesCloseEnough(requestedExercise.name, currentExerciseName)) return null;
-
-  return {
-    sessionId,
-    programId,
-    exerciseName: requestedExercise.name,
-    currentExerciseName,
-    reps,
-    weight: Number.isFinite(weight) ? weight : null,
-  };
-}
-
-function findMentionedProgramExercise(text, programId) {
-  const detail = window.getProgramDetail && programId ? window.getProgramDetail(programId) : window.PROGRAM_DETAIL;
-  const exercises = getAllProgramExercisesForCoach(detail);
-  let best = null;
-  let bestScore = 0;
-  exercises.forEach((exercise) => {
-    const name = normalizeCoachName(exercise.name || exercise.exercise_name);
-    if (!name) return;
-    const compactName = name.replace(/\s+/g, '');
-    const compactText = text.replace(/\s+/g, '');
-    const score = text.includes(name) || compactText.includes(compactName)
-      ? 1
-      : Math.max(nameSimilarity(text, name), compactSimilarity(compactText, compactName));
-    if (score > bestScore) {
-      best = exercise;
-      bestScore = score;
-    }
-  });
-  return bestScore >= 0.68 ? best : null;
-}
-
-function getAllProgramExercisesForCoach(detail) {
-  if (!detail) return [];
-  if (Array.isArray(detail.exercises) && detail.exercises.length) return detail.exercises;
-  return (detail.days || []).flatMap((day) =>
-    (day.blocks || []).flatMap((block) => block.exercises || []),
-  );
-}
-
-function namesCloseEnough(left, right) {
-  const leftName = normalizeCoachName(left);
-  const rightName = normalizeCoachName(right);
-  return leftName === rightName
-    || leftName.includes(rightName)
-    || rightName.includes(leftName)
-    || compactSimilarity(leftName.replace(/\s+/g, ''), rightName.replace(/\s+/g, '')) >= 0.8
-    || nameSimilarity(leftName, rightName) >= 0.68;
-}
-
-function compactSimilarity(left, right) {
-  if (!left || !right) return 0;
-  if (left === right || left.includes(right) || right.includes(left)) return 1;
-  const leftPairs = new Set(Array.from({ length: Math.max(left.length - 1, 0) }, (_, index) => left.slice(index, index + 2)));
-  const rightPairs = Array.from({ length: Math.max(right.length - 1, 0) }, (_, index) => right.slice(index, index + 2));
-  if (!leftPairs.size || !rightPairs.length) return 0;
-  const overlap = rightPairs.filter((pair) => leftPairs.has(pair)).length;
-  return overlap / Math.max(leftPairs.size, rightPairs.length, 1);
-}
-
 function App() {
   const auth = useAuth();
   const isNativeApp = Boolean(window.TRAINAR_NATIVE_APP);
@@ -231,7 +147,8 @@ function App() {
   // Where in the flow are we? Start at splash unless there's already a
   // signed-in user with a name — in that case skip straight to home.
   const initialScreen = (() => {
-    if (auth.user && auth.user.name) return 'home';
+    if (auth.user && auth.user.name && auth.user.trainingProfileComplete) return 'home';
+    if (auth.user && auth.user.name) return 'training';
     return 'splash';
   })();
   const [screen, setScreen] = React.useState(initialScreen);
@@ -294,6 +211,25 @@ function App() {
   }, []);
 
   React.useEffect(() => {
+    if (auth.pending || !auth.user) return;
+    if (!auth.user.name && !['splash', 'auth', 'name'].includes(screen)) {
+      setScreen('name');
+      return;
+    }
+    if (screen === 'splash' && auth.user.name && !auth.user.trainingProfileComplete) {
+      setScreen('training');
+      return;
+    }
+    if (auth.user.name && !auth.user.trainingProfileComplete && !['auth', 'name', 'training'].includes(screen)) {
+      setScreen('training');
+      return;
+    }
+    if (screen === 'splash' && auth.user.name && auth.user.trainingProfileComplete) {
+      setScreen('home');
+    }
+  }, [auth.pending, auth.user, screen]);
+
+  React.useEffect(() => {
     activeProgramIdRef.current = activeProgramId;
     activeSessionIdRef.current = activeSessionId;
     activeWorkoutDayRef.current = activeWorkoutDay;
@@ -329,10 +265,10 @@ function App() {
       });
     }
 
-    if (auth.user.name && SIGNUP_SCREENS.includes(screen)) {
+    if (auth.user.name && auth.user.trainingProfileComplete && ['splash', 'auth'].includes(screen)) {
       switchTab('home');
     }
-  }, [auth.pending, auth.user && auth.user.id, auth.user && auth.user.name]);
+  }, [auth.pending, auth.user && auth.user.id, auth.user && auth.user.name, auth.user && auth.user.trainingProfileComplete]);
 
   const startParsingFile = (file) => {
     if (!file) return;
@@ -421,6 +357,17 @@ function App() {
   const finishWorkout = async (sessionIdOverride = null, programIdOverride = null) => {
     const sessionIdToFinish = sessionIdOverride || activeSessionId;
     const programIdToFinish = programIdOverride || activeProgramId;
+    const program = (window.PROGRAMS || []).find((item) => item.id === programIdToFinish);
+    const optimisticWorkout = {
+      id: null,
+      date: new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+      name: program?.name || 'Workout',
+      totalVolume: 'Syncing',
+      duration: 'Syncing',
+      sets: 'Syncing',
+      rpe: '—',
+      exercises: [],
+    };
     loadedToGlassesRef.current = false;
     activeWorkoutDayRef.current = null;
     activeWorkoutStepRef.current = null;
@@ -431,26 +378,22 @@ function App() {
     setActiveWorkoutStep(null);
     setLastLoggedSet(null);
     setActiveRest(null);
+    setSelectedPastWorkout(optimisticWorkout);
+    setStack([]);
+    setScreen('past');
     if (window.finishWorkout && sessionIdToFinish) {
       try {
         const finishedSession = await window.finishWorkout(sessionIdToFinish, programIdToFinish);
-        if (finishedSession?.id && window.selectPastWorkout) {
-          const finishedWorkout = await window.selectPastWorkout(finishedSession.id);
-          setSelectedPastWorkout(finishedWorkout || window.PAST_WORKOUT || null);
-        } else {
-          setSelectedPastWorkout(window.PAST_WORKOUT || null);
-        }
+        setSelectedPastWorkout(window.PAST_WORKOUT || optimisticWorkout);
       } catch (err) {
         console.error('Could not finish workout:', err);
-        setSelectedPastWorkout(window.PAST_WORKOUT || null);
+        setSelectedPastWorkout(window.PAST_WORKOUT || optimisticWorkout);
       }
     } else {
-      setSelectedPastWorkout(window.PAST_WORKOUT || null);
+      setSelectedPastWorkout(window.PAST_WORKOUT || optimisticWorkout);
     }
     activeSessionIdRef.current = null;
     setActiveSessionId(null);
-    setStack([]);
-    setScreen('past');
   };
 
   const advanceWorkoutStep = () => {
@@ -497,62 +440,6 @@ function App() {
 
       if (detail.type !== 'voiceCommand') return;
 
-      const pendingLog = pendingLogConfirmationRef.current;
-      if (pendingLog && isAffirmativeCoachReply(transcript)) {
-        pendingLogConfirmationRef.current = null;
-        if (window.logWorkoutSet) {
-          window.logWorkoutSet(pendingLog.sessionId, {
-            exerciseName: pendingLog.exerciseName,
-            reps: pendingLog.reps,
-            weight: pendingLog.weight,
-            programId: pendingLog.programId,
-            currentExerciseName: activeWorkoutStepRef.current?.exerciseName,
-            allowOffCurrent: true,
-          }).then((result) => {
-            const logged = {
-              exerciseName: result?.exerciseLog?.exercise_name || pendingLog.exerciseName,
-              setNumber: result?.set?.set_number || null,
-              reps: result?.set?.reps ?? pendingLog.reps,
-              weight: result?.set?.load_value ?? pendingLog.weight,
-            };
-            lastLoggedSetRef.current = logged;
-            setLastLoggedSet(logged);
-            const response = `Logged ${logged.reps} reps of ${logged.exerciseName}${logged.weight != null ? ` at ${logged.weight} lb` : ''}.`;
-            setCoachResponse({ response });
-            setWakeActive(false);
-            window.dispatchEvent(new CustomEvent('trainar:speak', { detail: { text: response } }));
-          }).catch((err) => {
-            setCoachResponse({ response: err.message || 'Could not log that set.' });
-            setWakeActive(false);
-          });
-        }
-        return;
-      }
-
-      if (pendingLog && isNegativeCoachReply(transcript)) {
-        pendingLogConfirmationRef.current = null;
-        setCoachResponse({ response: 'Okay, I did not log it.' });
-        setWakeActive(false);
-        window.dispatchEvent(new CustomEvent('trainar:speak', { detail: { text: 'Okay, I did not log it.' } }));
-        return;
-      }
-
-      const pendingLogFromTranscript = buildPendingLogFromTranscript(transcript, {
-        programId: activeProgramIdRef.current,
-        sessionId: activeSessionIdRef.current,
-        currentExerciseName: activeWorkoutStepRef.current?.exerciseName,
-      });
-      if (pendingLogFromTranscript && window.logWorkoutSet) {
-        pendingLogConfirmationRef.current = pendingLogFromTranscript;
-        const response = `You are currently on ${pendingLogFromTranscript.currentExerciseName}. Did you mean to log ${pendingLogFromTranscript.exerciseName} instead?`;
-        setCoachResponse({ response, expectsFollowUp: true });
-        setWakeActive(true);
-        window.dispatchEvent(new CustomEvent('trainar:speak', {
-          detail: { text: response, continueListening: true },
-        }));
-        return;
-      }
-
       if (window.askTrainARCoach && transcript) {
         const clientTurnId = coachTurnIdRef.current + 1;
         coachTurnIdRef.current = clientTurnId;
@@ -579,6 +466,7 @@ function App() {
             step: currentStep,
             rest: currentRest,
           } : null,
+          pendingLogConfirmation: pendingLogConfirmationRef.current,
         }).catch((err) => {
           setCoachResponse({ response: err.message || 'Coach assistant failed.' });
           setWakeActive(false);
@@ -606,6 +494,8 @@ function App() {
           reps: detail.actionResult.reps,
           weight: detail.actionResult.weight,
         };
+      } else if (detail?.actionResult?.cleared_pending_confirmation || detail?.uiPatch?.type === 'set_logged') {
+        pendingLogConfirmationRef.current = null;
       }
       setCoachResponse(detail);
       setWakeActive(Boolean(detail?.expectsFollowUp));
@@ -844,6 +734,23 @@ function App() {
     }
   };
 
+  const deletePastWorkout = async (sessionId) => {
+    if (!sessionId || !window.deleteWorkoutSession) return;
+    const previousWorkout = selectedPastWorkout;
+    setSelectedPastWorkout(null);
+    setStack([]);
+    setActiveTab('calendar');
+    setScreen('calendar');
+    try {
+      await window.deleteWorkoutSession(sessionId);
+    } catch (err) {
+      console.error('Could not delete workout:', err);
+      setSelectedPastWorkout(previousWorkout);
+      setScreen('past');
+      setCoachResponse({ response: err.message || 'Could not delete that workout.' });
+    }
+  };
+
   const screens = {
     // ── Signup phase ────────────────────────────────────────────
     splash: (
@@ -856,22 +763,22 @@ function App() {
       <AuthScreen
         auth={auth}
         initialMode={mode}
-        onContinue={() => setScreen(mode === 'signup' ? 'name' : 'pair')}
+        onContinue={() => setScreen(mode === 'signup' ? 'name' : 'training')}
         onBack={() => setScreen('splash')}
       />
     ),
     name: (
       <NameScreen
         auth={auth}
-        onContinue={() => setScreen('pair')}
+        onContinue={() => setScreen('training')}
         onBack={() => setScreen('auth')}
       />
     ),
-    pair: (
-      <PairScreen
-        onContinue={() => switchTab('home')}
-        onSkip={() => switchTab('home')}
-        onBack={() => setScreen(auth.user && auth.user.name ? 'name' : 'auth')}
+    training: (
+      <TrainingProfileScreen
+        auth={auth}
+        onContinue={() => (stack.length ? back() : switchTab('home'))}
+        onBack={() => (stack.length ? back() : setScreen(auth.user && auth.user.name ? 'name' : 'auth'))}
       />
     ),
 
@@ -900,6 +807,7 @@ function App() {
         key={`profile-${dataVersion}-${glassesState.connected ? 'connected' : 'idle'}`}
         user={auth.user}
         glassesState={glassesState}
+        onEditTraining={() => go('training')}
       />
     ),
 
@@ -1016,11 +924,18 @@ function App() {
         }}
       />
     ),
-    past: <PastWorkoutScreen key={`past-${selectedPastWorkout?.id || dataVersion}`} workout={selectedPastWorkout || window.PAST_WORKOUT} onBack={back} />,
+    past: (
+      <PastWorkoutScreen
+        key={`past-${selectedPastWorkout?.id || dataVersion}`}
+        workout={selectedPastWorkout || window.PAST_WORKOUT}
+        onBack={back}
+        onDelete={deletePastWorkout}
+      />
+    ),
   };
 
   const showTabBar = SCREENS_WITH_TABBAR.includes(screen);
-  const showSignoutDev = !SIGNUP_SCREENS.includes(screen) && screen !== 'pair';
+  const showSignoutDev = !SIGNUP_SCREENS.includes(screen);
 
   const appSurface = (
     <div style={{
@@ -1028,7 +943,7 @@ function App() {
       height: '100%',
       minHeight: isNativeApp ? '100vh' : 'auto',
       position: 'relative',
-      background: 'var(--bg)',
+      background: screen === 'hud' ? 'transparent' : 'var(--bg)',
       color: 'var(--text-1)',
       overflow: 'hidden',
     }}>
@@ -1039,6 +954,7 @@ function App() {
       {screen !== 'hud' && coachResponse?.response && (
         <CoachOverlay
           response={coachResponse.response}
+          sources={coachResponse.sources || []}
           onClose={() => setCoachResponse(null)}
         />
       )}
@@ -1052,7 +968,7 @@ function App() {
       position: 'relative',
       width: isNativeApp ? '100vw' : 'auto',
       height: isNativeApp ? '100vh' : 'auto',
-      background: 'var(--bg)',
+      background: screen === 'hud' ? 'transparent' : 'var(--bg)',
     }}>
       {isNativeApp ? appSurface : (
         <IOSDevice width={PROTOTYPE_W} height={PROTOTYPE_H} dark={true}>
@@ -1097,7 +1013,7 @@ const WakeListeningBorder = ({ isNativeApp }) => (
   />
 );
 
-const CoachOverlay = ({ response, onClose }) => (
+const CoachOverlay = ({ response, sources = [], onClose }) => (
   <div style={{
     position: 'absolute',
     left: 18,
@@ -1133,6 +1049,25 @@ const CoachOverlay = ({ response, onClose }) => (
       <div style={{ fontSize: 13, lineHeight: 1.35, color: 'var(--text-1)' }}>
         {response}
       </div>
+      {sources.length > 0 && (
+        <div style={{
+          marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 6,
+          color: 'var(--text-3)', fontSize: 10,
+        }}>
+          {sources.slice(0, 2).map((source) => (
+            <span key={source.key} style={{
+              border: '1px solid rgba(197,242,62,0.18)',
+              background: 'rgba(197,242,62,0.06)',
+              color: 'var(--accent)',
+              borderRadius: 999,
+              padding: '3px 7px',
+              whiteSpace: 'nowrap',
+            }}>
+              {source.authors} {source.year}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
     <button
       onClick={onClose}

--- a/ios/assistant.js
+++ b/ios/assistant.js
@@ -36,6 +36,7 @@
       action: payload.action || null,
       actionResult: payload.action_result || null,
       uiPatch: payload.ui_patch || null,
+      sources: payload.sources || [],
       mode: payload.mode || 'chat',
       clientTurnId: options.clientTurnId || null,
     };
@@ -84,7 +85,9 @@
     return {
       activeProgramId,
       activeProgram,
+      trainingProfile: window.TRAINAR_TRAINING_PROFILE || null,
       currentWorkout: options.currentWorkout || null,
+      pendingLogConfirmation: options.pendingLogConfirmation || null,
       programs: (window.PROGRAMS || []).slice(0, 10),
       programDetail: window.PROGRAM_DETAIL || null,
       recentSessions: (window.TRAINAR_SESSIONS || []).slice(0, 20),

--- a/ios/assistant.js
+++ b/ios/assistant.js
@@ -29,8 +29,10 @@
     // Normalize on `response` so existing listeners (CoachOverlay, wake-word
     // border reset) keep working unchanged.
     const reply = String(payload.reply || '').trim();
+    const expectsFollowUp = looksLikeQuestion(reply);
     const normalized = {
       response: reply,
+      expectsFollowUp,
       action: payload.action || null,
       actionResult: payload.action_result || null,
       uiPatch: payload.ui_patch || null,
@@ -54,17 +56,25 @@
     // AppleVoiceBridge handles with AVSpeechSynthesizer.
     if (reply) {
       window.dispatchEvent(new CustomEvent('trainar:speak', {
-        detail: { text: reply },
+        detail: { text: reply, continueListening: expectsFollowUp },
       }));
     }
 
     if (window.sendTrainARNativeCommand) {
       window.sendTrainARNativeCommand('coachResponse', {
         response: reply,
+        continueListening: expectsFollowUp,
       });
     }
 
     return normalized;
+  }
+
+  function looksLikeQuestion(value) {
+    const text = String(value || '').trim();
+    if (!text) return false;
+    if (/[?]\s*$/.test(text)) return true;
+    return /^(what|which|who|when|where|why|how|do|does|did|can|could|would|should|is|are|am|will)\b/i.test(text);
   }
 
   function buildCoachContext(options = {}) {

--- a/ios/auth.js
+++ b/ios/auth.js
@@ -17,15 +17,36 @@
     if (window.location.protocol === 'file:') return 'http://127.0.0.1:5002/ios/';
     return window.location.origin + window.location.pathname;
   };
+  const BASE_PROFILE_SELECT = 'id,email,display_name,units,timezone,onboarded_at';
+  const TRAINING_PROFILE_SELECT = `${BASE_PROFILE_SELECT},training_goal,training_experience,workout_days_per_week,workout_session_minutes,available_equipment,coach_style,evidence_preference,movement_constraints,training_onboarded_at`;
+  const isMissingTrainingColumnError = (error) => {
+    const message = String(error?.message || error?.details || '');
+    return /profiles\.(training_goal|training_experience|workout_days_per_week|workout_session_minutes|available_equipment|coach_style|evidence_preference|movement_constraints|training_onboarded_at).*does not exist/i.test(message)
+      || /Could not find .*training_/i.test(message);
+  };
 
   const toScreenUser = (authUser, profile) => {
     if (!authUser) return null;
+    const trainingProfile = profile ? {
+      trainingGoal: profile.training_goal || null,
+      trainingExperience: profile.training_experience || null,
+      workoutDaysPerWeek: profile.workout_days_per_week || null,
+      workoutSessionMinutes: profile.workout_session_minutes || null,
+      availableEquipment: profile.available_equipment || [],
+      coachStyle: profile.coach_style || 'direct',
+      evidencePreference: profile.evidence_preference || 'concise',
+      movementConstraints: profile.movement_constraints || '',
+      trainingOnboardedAt: profile.training_onboarded_at || null,
+    } : null;
+    window.TRAINAR_TRAINING_PROFILE = trainingProfile;
     return {
       id: authUser.id,
       email: authUser.email || profile?.email || '',
       name: profile?.display_name || null,
       units: profile?.units || 'imperial',
       timezone: profile?.timezone || 'America/Los_Angeles',
+      trainingProfile,
+      trainingProfileComplete: Boolean(profile?.training_onboarded_at),
     };
   };
 
@@ -33,10 +54,19 @@
     if (!client() || !userId) return null;
     const { data, error } = await client()
       .from('profiles')
-      .select('id,email,display_name,units,timezone,onboarded_at')
+      .select(TRAINING_PROFILE_SELECT)
       .eq('id', userId)
       .maybeSingle();
 
+    if (error && isMissingTrainingColumnError(error)) {
+      const fallback = await client()
+        .from('profiles')
+        .select(BASE_PROFILE_SELECT)
+        .eq('id', userId)
+        .maybeSingle();
+      if (fallback.error) throw fallback.error;
+      return fallback.data;
+    }
     if (error) throw error;
     return data;
   }
@@ -49,9 +79,18 @@
     const { data, error } = await client()
       .from('profiles')
       .upsert({ id: authUser.id, email: authUser.email || null }, { onConflict: 'id' })
-      .select('id,email,display_name,units,timezone,onboarded_at')
+      .select(TRAINING_PROFILE_SELECT)
       .single();
 
+    if (error && isMissingTrainingColumnError(error)) {
+      const fallback = await client()
+        .from('profiles')
+        .upsert({ id: authUser.id, email: authUser.email || null }, { onConflict: 'id' })
+        .select(BASE_PROFILE_SELECT)
+        .single();
+      if (fallback.error) throw fallback.error;
+      return fallback.data;
+    }
     if (error) throw error;
     return data;
   }
@@ -164,13 +203,67 @@
 
       const { data, error: updateError } = await client()
         .from('profiles')
-        .update({ display_name: name, onboarded_at: new Date().toISOString() })
+        .update({ display_name: name })
         .eq('id', user.id)
-        .select('id,email,display_name,units,timezone,onboarded_at')
+        .select(TRAINING_PROFILE_SELECT)
+        .single();
+
+      if (updateError && isMissingTrainingColumnError(updateError)) {
+        const fallback = await client()
+          .from('profiles')
+          .update({ display_name: name })
+          .eq('id', user.id)
+          .select(BASE_PROFILE_SELECT)
+          .single();
+        if (fallback.error) {
+          setError(fallback.error.message);
+          setPending(false);
+          return false;
+        }
+        setUser(toScreenUser({ id: user.id, email: user.email }, fallback.data));
+        setPending(false);
+        return true;
+      }
+      if (updateError) {
+        setError(updateError.message);
+        setPending(false);
+        return false;
+      }
+
+      setUser(toScreenUser({ id: user.id, email: user.email }, data));
+      setPending(false);
+      return true;
+    };
+
+    const setTrainingProfile = async (profile) => {
+      if (!user) return false;
+      setError(null);
+      setPending(true);
+
+      const row = {
+        training_goal: profile.trainingGoal,
+        training_experience: profile.trainingExperience,
+        workout_days_per_week: Number(profile.workoutDaysPerWeek),
+        workout_session_minutes: Number(profile.workoutSessionMinutes),
+        available_equipment: profile.availableEquipment || [],
+        coach_style: profile.coachStyle || 'direct',
+        evidence_preference: profile.evidencePreference || 'concise',
+        movement_constraints: profile.movementConstraints || null,
+        training_onboarded_at: new Date().toISOString(),
+        onboarded_at: new Date().toISOString(),
+      };
+
+      const { data, error: updateError } = await client()
+        .from('profiles')
+        .update(row)
+        .eq('id', user.id)
+        .select(TRAINING_PROFILE_SELECT)
         .single();
 
       if (updateError) {
-        setError(updateError.message);
+        setError(isMissingTrainingColumnError(updateError)
+          ? 'Training profile fields are not in Supabase yet. Run the latest migration, then try again.'
+          : updateError.message);
         setPending(false);
         return false;
       }
@@ -184,11 +277,12 @@
       setPending(true);
       await client().auth.signOut();
       setUser(null);
+      window.TRAINAR_TRAINING_PROFILE = null;
       setPending(false);
       if (window.resetTrainarData) window.resetTrainarData();
     };
 
-    return { user, pending, error, signUp, signIn, setName, signOut };
+    return { user, pending, error, signUp, signIn, setName, setTrainingProfile, signOut };
   }
 
   function scorePassword(pw) {

--- a/ios/data.js
+++ b/ios/data.js
@@ -33,6 +33,50 @@
     window.dispatchEvent(new CustomEvent('trainar:data'));
   }
 
+  function upsertTrainarProgramCache(program, detail) {
+    const programId = program?.id || detail?.programId;
+    if (!programId) return null;
+
+    const nextDetail = detail || window.TRAINAR_PROGRAM_DETAILS[programId] || null;
+    const nextProgram = {
+      ...(window.PROGRAMS || []).find((item) => item.id === programId),
+      ...(program || {}),
+      id: programId,
+      name: program?.name || detail?.name || program?.title || 'Generated workout',
+    };
+
+    window.PROGRAMS = [
+      nextProgram,
+      ...(window.PROGRAMS || []).filter((item) => item.id !== programId),
+    ];
+    if (nextDetail) {
+      window.TRAINAR_PROGRAM_DETAILS = {
+        ...(window.TRAINAR_PROGRAM_DETAILS || {}),
+        [programId]: nextDetail,
+      };
+      window.PROGRAM_DETAIL = nextDetail;
+      window.PARSED_PROGRAM = nextDetail;
+    }
+    emitDataChange();
+    return nextDetail;
+  }
+
+  function removeTrainarProgramCache(programId) {
+    if (!programId) return;
+    window.PROGRAMS = (window.PROGRAMS || []).filter((item) => item.id !== programId);
+    if (window.TRAINAR_PROGRAM_DETAILS) {
+      delete window.TRAINAR_PROGRAM_DETAILS[programId];
+    }
+    if (window.PROGRAM_DETAIL?.programId === programId) {
+      const nextProgram = (window.PROGRAMS || [])[0];
+      window.PROGRAM_DETAIL = nextProgram
+        ? window.TRAINAR_PROGRAM_DETAILS[nextProgram.id] || { exercises: [], days: [] }
+        : { exercises: [], days: [] };
+      window.PARSED_PROGRAM = window.PROGRAM_DETAIL;
+    }
+    emitDataChange();
+  }
+
   function resetTrainarData() {
     window.PROGRAMS = [];
     window.PROGRAM_DETAIL = { exercises: [], days: [] };
@@ -276,15 +320,21 @@
   }
 
   async function archiveProgram(programId) {
-    if (!programId) return;
-    const { error } = await client()
+    if (!programId) throw new Error('No program selected to discard.');
+    const { data, error } = await client()
       .from('programs')
       .update({ archived_at: new Date().toISOString() })
-      .eq('id', programId);
+      .eq('id', programId)
+      .select('id')
+      .single();
     throwIfError(error);
+    if (!data?.id) throw new Error('Could not discard this program.');
 
-    const { data } = await client().auth.getUser();
-    if (data.user) await loadTrainarData(data.user.id);
+    removeTrainarProgramCache(programId);
+
+    const authRes = await client().auth.getUser();
+    if (authRes.data.user) await loadTrainarData(authRes.data.user.id);
+    return data.id;
   }
 
   async function pairDemoDevice() {
@@ -336,21 +386,17 @@
 
   async function finishWorkout(sessionId, programId) {
     if (!sessionId) return null;
-    const detail = window.getProgramDetail(programId) || window.PROGRAM_DETAIL || { exercises: [] };
-    const exercises = getDetailExercises(detail);
-    const totalSets = exercises.reduce((sum, exercise) => sum + normalizeSetCount(exercise.sets), 0);
-    const startedAt = new Date(Date.now() - 45 * 60 * 1000);
     const finishedAt = new Date();
+    const totals = await loadSessionTotals(sessionId);
 
     const { data: session, error } = await client()
       .from('workout_sessions')
       .update({
         status: 'completed',
-        started_at: startedAt.toISOString(),
         finished_at: finishedAt.toISOString(),
-        duration_seconds: Math.round((finishedAt - startedAt) / 1000),
-        total_sets: totalSets,
-        total_volume: 0,
+        duration_seconds: totals.durationSeconds,
+        total_sets: totals.totalSets,
+        total_volume: totals.totalVolume,
         avg_rpe: null,
         auto_tracked_ratio: null,
       })
@@ -361,12 +407,61 @@
 
     const { data: authData } = await client().auth.getUser();
     if (authData.user) await loadTrainarData(authData.user.id);
+    window.PAST_WORKOUT = await loadPastWorkout(session, window.TRAINAR_PRS || []);
+    emitDataChange();
     return session;
   }
 
-  async function logWorkoutSet(sessionId, { exerciseName, reps, weight, rpe = null } = {}) {
+  async function loadSessionTotals(sessionId) {
+    const sessionRes = await client()
+      .from('workout_sessions')
+      .select('started_at,created_at,total_sets,total_volume')
+      .eq('id', sessionId)
+      .single();
+    throwIfError(sessionRes.error);
+
+    const logsRes = await client()
+      .from('workout_exercise_logs')
+      .select('id')
+      .eq('session_id', sessionId);
+    throwIfError(logsRes.error);
+
+    const logIds = (logsRes.data || []).map((log) => log.id);
+    const setsRes = logIds.length
+      ? await client()
+        .from('workout_sets')
+        .select('reps,load_value')
+        .in('exercise_log_id', logIds)
+      : { data: [] };
+    throwIfError(setsRes.error);
+
+    const sets = setsRes.data || [];
+    const totalVolume = sets.reduce((sum, set) => sum + Number(set.reps || 0) * Number(set.load_value || 0), 0);
+    const startedAt = new Date(sessionRes.data?.started_at || sessionRes.data?.created_at || Date.now());
+    const durationSeconds = Number.isNaN(startedAt.getTime())
+      ? null
+      : Math.max(0, Math.round((Date.now() - startedAt.getTime()) / 1000));
+
+    return {
+      totalSets: sets.length || Number(sessionRes.data?.total_sets || 0),
+      totalVolume: totalVolume || Number(sessionRes.data?.total_volume || 0),
+      durationSeconds,
+    };
+  }
+
+  async function logWorkoutSet(sessionId, { exerciseName, reps, weight, rpe = null, programId = null, currentExerciseName = null, allowOffCurrent = false } = {}) {
     if (!sessionId) throw new Error('Start a workout before logging sets.');
-    const cleanExerciseName = String(exerciseName || '').trim();
+    const resolvedExercise = resolvePlannedExerciseName(programId, exerciseName || currentExerciseName);
+    const currentExercise = resolvePlannedExerciseName(programId, currentExerciseName);
+    if (!allowOffCurrent && exerciseName && currentExercise) {
+      const requestedName = resolvedExercise || String(exerciseName).trim();
+      const matchesCurrent = normalizeName(requestedName) === normalizeName(currentExercise)
+        || nameSimilarity(normalizeName(exerciseName), normalizeName(currentExercise)) >= 0.68;
+      if (!matchesCurrent) {
+        throw new Error(`You are currently on ${currentExercise}. Did you mean to log ${requestedName} instead?`);
+      }
+    }
+    const cleanExerciseName = String(resolvedExercise || exerciseName || currentExerciseName || '').trim();
     const parsedReps = Number.parseInt(reps, 10);
     const parsedWeight = weight == null ? null : Number.parseFloat(weight);
 
@@ -451,6 +546,23 @@
       set: insertedSet.data,
       session: updatedSession.data,
     };
+  }
+
+  function resolvePlannedExerciseName(programId, exerciseName) {
+    const query = normalizeName(exerciseName);
+    if (!query) return null;
+    const detail = (programId && getProgramDetail(programId)) || window.PROGRAM_DETAIL || {};
+    const exercises = getDetailExercises(detail);
+    if (!exercises.length) return null;
+    const exact = exercises.find((exercise) => normalizeName(exercise.name) === query);
+    if (exact) return exact.name;
+    const scored = exercises
+      .map((exercise) => ({
+        name: exercise.name,
+        score: nameSimilarity(query, normalizeName(exercise.name)),
+      }))
+      .sort((left, right) => right.score - left.score)[0];
+    return scored && scored.score >= 0.68 ? scored.name : null;
   }
 
   async function loadPastWorkout(session, prs) {
@@ -656,6 +768,28 @@
     return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
   }
 
+  function nameSimilarity(left, right) {
+    if (!left || !right) return 0;
+    if (left === right || left.includes(right) || right.includes(left)) return 1;
+    const compactLeft = left.replace(/\s+/g, '');
+    const compactRight = right.replace(/\s+/g, '');
+    if (compactLeft === compactRight || compactLeft.includes(compactRight) || compactRight.includes(compactLeft)) return 1;
+    const leftWords = new Set(left.split(' '));
+    const rightWords = right.split(' ');
+    const overlap = rightWords.filter((word) => leftWords.has(word)).length;
+    const tokenScore = overlap / Math.max(leftWords.size, rightWords.length, 1);
+    return Math.max(tokenScore, compactSimilarity(compactLeft, compactRight));
+  }
+
+  function compactSimilarity(left, right) {
+    if (!left || !right) return 0;
+    const leftPairs = new Set(Array.from({ length: Math.max(left.length - 1, 0) }, (_, index) => left.slice(index, index + 2)));
+    const rightPairs = Array.from({ length: Math.max(right.length - 1, 0) }, (_, index) => right.slice(index, index + 2));
+    if (!leftPairs.size || !rightPairs.length) return 0;
+    const overlap = rightPairs.filter((pair) => leftPairs.has(pair)).length;
+    return overlap / Math.max(leftPairs.size, rightPairs.length, 1);
+  }
+
   function getDetailDays(detail) {
     if (Array.isArray(detail.days)) return detail.days;
     return [];
@@ -758,5 +892,7 @@
     logWorkoutSet,
     selectPastWorkout,
     getProgramDetail,
+    upsertTrainarProgramCache,
+    removeTrainarProgramCache,
   });
 })();

--- a/ios/data.js
+++ b/ios/data.js
@@ -412,6 +412,48 @@
     return session;
   }
 
+  async function deleteWorkoutSession(sessionId) {
+    if (!sessionId) throw new Error('No workout selected to delete.');
+
+    const logsRes = await client()
+      .from('workout_exercise_logs')
+      .select('id')
+      .eq('session_id', sessionId);
+    throwIfError(logsRes.error);
+
+    const logIds = (logsRes.data || []).map((log) => log.id);
+    if (logIds.length) {
+      const setsDeleteRes = await client()
+        .from('workout_sets')
+        .delete()
+        .in('exercise_log_id', logIds);
+      throwIfError(setsDeleteRes.error);
+
+      const logsDeleteRes = await client()
+        .from('workout_exercise_logs')
+        .delete()
+        .in('id', logIds);
+      throwIfError(logsDeleteRes.error);
+    }
+
+    const sessionDeleteRes = await client()
+      .from('workout_sessions')
+      .delete()
+      .eq('id', sessionId);
+    throwIfError(sessionDeleteRes.error);
+
+    window.TRAINAR_SESSIONS = (window.TRAINAR_SESSIONS || []).filter((session) => session.id !== sessionId);
+    window.HISTORY = (window.HISTORY || []).filter((session) => session.id !== sessionId);
+    if (window.PAST_WORKOUT?.id === sessionId) {
+      window.PAST_WORKOUT = null;
+    }
+
+    const { data: authData } = await client().auth.getUser();
+    if (authData.user) await loadTrainarData(authData.user.id);
+    emitDataChange();
+    return sessionId;
+  }
+
   async function loadSessionTotals(sessionId) {
     const sessionRes = await client()
       .from('workout_sessions')
@@ -889,6 +931,7 @@
     pairDemoDevice,
     startWorkout,
     finishWorkout,
+    deleteWorkoutSession,
     logWorkoutSet,
     selectPastWorkout,
     getProgramDetail,

--- a/ios/index.html
+++ b/ios/index.html
@@ -60,6 +60,7 @@
   <script type="text/babel" src="screens-signup.jsx"></script>
   <script type="text/babel" src="screens-add-program.jsx"></script>
   <script type="text/babel" src="screens-main.jsx"></script>
+  <script type="text/babel" src="screens-hud.jsx"></script>
   <script type="text/babel" src="screens-program-detail.jsx"></script>
   <script type="text/babel" src="screens-past-workout.jsx"></script>
   <script type="text/babel" src="screens-calendar.jsx"></script>

--- a/ios/index.html
+++ b/ios/index.html
@@ -33,6 +33,11 @@
     html.trainar-native #root {
       display: block;
     }
+    html.trainar-hud-active,
+    html.trainar-hud-active body,
+    html.trainar-hud-active #root {
+      background: transparent !important;
+    }
   </style>
 </head>
 <body>

--- a/ios/screens-calendar.jsx
+++ b/ios/screens-calendar.jsx
@@ -5,9 +5,11 @@ const CalendarScreen = ({ onOpenWorkout }) => {
   const sessions = window.TRAINAR_SESSIONS || [];
   const initialMonth = getInitialCalendarMonth(sessions);
   const [visibleMonth, setVisibleMonth] = React.useState(initialMonth);
+  const [selectedDay, setSelectedDay] = React.useState(null);
   const monthModel = buildCalendarMonth(sessions, visibleMonth.year, visibleMonth.monthIndex);
   const monthDays = monthModel.days;
   const firstDayOffset = monthModel.firstDayOffset;
+  const selectedDaySessions = selectedDay ? (monthModel.sessionsByDay[selectedDay] || []) : [];
 
   const stats = monthModel.stats || window.ACTIVITY_STATS || {
     sessions: monthDays.filter((d) => d > 0).length,
@@ -65,7 +67,7 @@ const CalendarScreen = ({ onOpenWorkout }) => {
         display: 'flex', alignItems: 'center', justifyContent: 'space-between',
       }}>
         <button
-          onClick={() => setVisibleMonth(shiftMonth(visibleMonth, -1))}
+          onClick={() => { setSelectedDay(null); setVisibleMonth(shiftMonth(visibleMonth, -1)); }}
           className="press"
           style={{
           width: 32, height: 32, borderRadius: 9999,
@@ -75,7 +77,7 @@ const CalendarScreen = ({ onOpenWorkout }) => {
         ><Icon name="chevron-left" size={14} /></button>
         <div style={{ fontSize: 16, fontWeight: 600 }}>{monthLabel(visibleMonth)}</div>
         <button
-          onClick={() => setVisibleMonth(shiftMonth(visibleMonth, 1))}
+          onClick={() => { setSelectedDay(null); setVisibleMonth(shiftMonth(visibleMonth, 1)); }}
           className="press"
           style={{
           width: 32, height: 32, borderRadius: 9999,
@@ -108,11 +110,18 @@ const CalendarScreen = ({ onOpenWorkout }) => {
           const today = appDateParts(new Date().toISOString());
           const isToday = day === today.day && visibleMonth.monthIndex === today.monthIndex && visibleMonth.year === today.year;
           const cell = intensities[v];
-          const sessionId = monthModel.sessionIds[day]?.id;
+          const daySessions = monthModel.sessionsByDay[day] || [];
           return (
             <button
               key={i}
-              onClick={() => v > 0 && sessionId && onOpenWorkout && onOpenWorkout(sessionId)}
+              onClick={() => {
+                if (!v || !daySessions.length) return;
+                if (daySessions.length === 1) {
+                  onOpenWorkout && onOpenWorkout(daySessions[0].id);
+                } else {
+                  setSelectedDay(day);
+                }
+              }}
               className={v > 0 ? 'press' : ''}
               style={{
                 aspectRatio: '1',
@@ -134,6 +143,12 @@ const CalendarScreen = ({ onOpenWorkout }) => {
               {v > 0 && (
                 <div style={{ width: 6, height: 6, borderRadius: 3, background: cell.dot, zIndex: 1 }} />
               )}
+              {daySessions.length > 1 && (
+                <div className="mono" style={{
+                  position: 'absolute', right: 4, bottom: 3, zIndex: 2,
+                  fontSize: 8, color: 'var(--accent)', fontWeight: 700,
+                }}>{daySessions.length}</div>
+              )}
               {v > 0 && (
                 <div style={{ position: 'absolute', inset: 0, background: cell.bg, opacity: 0.5 }} />
               )}
@@ -141,6 +156,62 @@ const CalendarScreen = ({ onOpenWorkout }) => {
           );
         })}
       </div>
+
+      {selectedDaySessions.length > 1 && (
+        <div style={{ padding: '0 20px 18px' }}>
+          <div style={{
+            padding: 14,
+            borderRadius: 'var(--r-card)',
+            background: 'var(--surface-1)',
+            border: '1px solid var(--hairline)',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-2)' }}>
+                {monthLabel(visibleMonth)} {selectedDay}
+              </div>
+              <button
+                onClick={() => setSelectedDay(null)}
+                aria-label="Close day workouts"
+                style={{
+                  width: 26, height: 26, borderRadius: 9999,
+                  border: '1px solid var(--hairline)',
+                  background: 'var(--surface-2)',
+                  color: 'var(--text-2)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  cursor: 'pointer',
+                }}
+              >
+                <Icon name="x" size={13} />
+              </button>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {selectedDaySessions.map((session) => (
+                <button
+                  key={session.id}
+                  onClick={() => onOpenWorkout && onOpenWorkout(session.id)}
+                  className="press"
+                  style={{
+                    width: '100%',
+                    padding: '12px 12px',
+                    borderRadius: 12,
+                    border: '1px solid var(--hairline)',
+                    background: 'var(--surface-2)',
+                    color: 'var(--text-1)',
+                    textAlign: 'left',
+                    fontFamily: 'var(--font-sans)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <div style={{ fontSize: 13, fontWeight: 650 }}>{session.title || 'Workout'}</div>
+                  <div className="mono" style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 3 }}>
+                    {formatSessionTime(session.started_at || session.created_at)} · {session.total_sets || 0} sets
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Recent sessions list. */}
       <div style={{ padding: '0 20px' }}>
@@ -204,6 +275,7 @@ function buildCalendarMonth(sessions, year, monthIndex) {
   const firstDayOffset = (firstWeekday + 6) % 7;
   const days = Array.from({ length: daysInMonth }, () => 0);
   const sessionIds = {};
+  const sessionsByDay = {};
 
   sessions.forEach((session) => {
     const parts = appDateParts(session.started_at || session.created_at);
@@ -216,9 +288,15 @@ function buildCalendarMonth(sessions, year, monthIndex) {
     if (!sessionIds[parts.day] || parts.sortKey > sessionIds[parts.day].sortKey) {
       sessionIds[parts.day] = { ...session, sortKey: parts.sortKey };
     }
+    sessionsByDay[parts.day] = sessionsByDay[parts.day] || [];
+    sessionsByDay[parts.day].push({ ...session, sortKey: parts.sortKey });
   });
 
-  return { days, firstDayOffset, sessionIds, stats: buildCalendarStats(sessions, year, monthIndex) };
+  Object.keys(sessionsByDay).forEach((day) => {
+    sessionsByDay[day].sort((left, right) => right.sortKey.localeCompare(left.sortKey));
+  });
+
+  return { days, firstDayOffset, sessionIds, sessionsByDay, stats: buildCalendarStats(sessions, year, monthIndex) };
 }
 
 function buildCalendarStats(sessions, year, monthIndex) {
@@ -266,6 +344,15 @@ function shiftMonth(month, delta) {
 function monthLabel(month) {
   return new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' })
     .format(new Date(Date.UTC(month.year, month.monthIndex, 1)));
+}
+
+function formatSessionTime(value) {
+  if (!value) return '';
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'America/Los_Angeles',
+  }).format(new Date(value));
 }
 
 function appDateParts(value) {

--- a/ios/screens-hud.jsx
+++ b/ios/screens-hud.jsx
@@ -1,0 +1,549 @@
+// HUD demo viewer.
+//
+// This is intentionally optional: the normal TrainAR app does not depend on
+// camera access or the HUD screen. When opened, it renders a glasses-style
+// overlay over a live phone camera preview when possible, with a mock motion
+// background as the fallback.
+
+const HUD_DEMO_FACING_MODES = ['environment', 'user'];
+
+const HudDemoScreen = ({
+  programId,
+  day,
+  step,
+  rest,
+  coachResponse,
+  onClose,
+}) => {
+  const videoRef = React.useRef(null);
+  const streamRef = React.useRef(null);
+  const [cameraStatus, setCameraStatus] = React.useState('idle');
+  const [sourceMode, setSourceMode] = React.useState('mock');
+  const [facingMode, setFacingMode] = React.useState('environment');
+  const [now, setNow] = React.useState(() => Date.now());
+  const [externalState, setExternalState] = React.useState(() => window.TRAINAR_HUD_STATE || null);
+
+  const hudState = deriveTrainARHudState({
+    programId,
+    day,
+    step,
+    rest,
+    coachResponse,
+    now,
+    fallback: externalState,
+  });
+
+  React.useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  React.useEffect(() => {
+    const onHudState = (event) => setExternalState(event.detail || null);
+    window.addEventListener('trainar:hud-state', onHudState);
+    return () => window.removeEventListener('trainar:hud-state', onHudState);
+  }, []);
+
+  React.useEffect(() => () => stopHudCameraStream(streamRef), []);
+
+  const startCamera = React.useCallback(async (nextFacingMode = facingMode) => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setCameraStatus('unavailable');
+      setSourceMode('mock');
+      return;
+    }
+
+    stopHudCameraStream(streamRef);
+    setCameraStatus('starting');
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: {
+          facingMode: { ideal: nextFacingMode },
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+        },
+      });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+      setFacingMode(nextFacingMode);
+      setSourceMode('camera');
+      setCameraStatus('streaming');
+    } catch (err) {
+      console.warn('HUD camera preview unavailable:', err);
+      setCameraStatus('failed');
+      setSourceMode('mock');
+    }
+  }, [facingMode]);
+
+  const useMockSource = () => {
+    stopHudCameraStream(streamRef);
+    setSourceMode('mock');
+    setCameraStatus('idle');
+  };
+
+  const switchCamera = () => {
+    const nextIndex = (HUD_DEMO_FACING_MODES.indexOf(facingMode) + 1) % HUD_DEMO_FACING_MODES.length;
+    startCamera(HUD_DEMO_FACING_MODES[nextIndex]);
+  };
+
+  return (
+    <Screen padTop={0} padBottom={0} style={{ background: '#050605', overflow: 'hidden' }}>
+      <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', background: '#050605' }}>
+        {sourceMode === 'camera' ? (
+          <video
+            ref={videoRef}
+            playsInline
+            muted
+            autoPlay
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              transform: facingMode === 'user' ? 'scaleX(-1)' : 'none',
+              background: '#050605',
+            }}
+          />
+        ) : (
+          <HudMockScene now={now} />
+        )}
+
+        <HudLensVignette />
+        <HudOverlay state={hudState} />
+      </div>
+
+      <div style={{
+        position: 'absolute',
+        top: 'calc(env(safe-area-inset-top, 0px) + 14px)',
+        left: 14,
+        right: 14,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 10,
+        zIndex: 10,
+      }}>
+        <button onClick={onClose} className="press" aria-label="Close HUD demo" style={hudIconButtonStyle()}>
+          <Icon name="chevron-left" size={19} />
+        </button>
+        <div style={{
+          height: 34,
+          padding: '0 12px',
+          borderRadius: 9999,
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          background: 'rgba(0,0,0,0.42)',
+          border: '1px solid rgba(255,255,255,0.14)',
+          color: '#f8faf5',
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
+          fontSize: 12,
+          fontWeight: 700,
+        }}>
+          <span style={{
+            width: 7,
+            height: 7,
+            borderRadius: 9999,
+            background: sourceMode === 'camera' ? '#c5f23e' : '#f5c542',
+            boxShadow: sourceMode === 'camera' ? '0 0 12px rgba(197,242,62,0.8)' : '0 0 12px rgba(245,197,66,0.7)',
+          }} />
+          {sourceMode === 'camera' ? 'Camera HUD' : 'Mock HUD'}
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {sourceMode === 'camera' && (
+            <button onClick={switchCamera} className="press" aria-label="Switch camera" style={hudIconButtonStyle()}>
+              <Icon name="rotate" size={18} />
+            </button>
+          )}
+          <button
+            onClick={sourceMode === 'camera' ? useMockSource : () => startCamera()}
+            className="press"
+            aria-label={sourceMode === 'camera' ? 'Use mock source' : 'Start camera'}
+            style={hudIconButtonStyle()}
+          >
+            <Icon name={sourceMode === 'camera' ? 'video' : 'camera'} size={18} />
+          </button>
+        </div>
+      </div>
+
+      {cameraStatus === 'failed' && (
+        <div style={{
+          position: 'absolute',
+          left: 18,
+          right: 18,
+          bottom: 'calc(env(safe-area-inset-bottom, 0px) + 22px)',
+          zIndex: 12,
+          padding: '10px 12px',
+          borderRadius: 12,
+          background: 'rgba(0,0,0,0.58)',
+          border: '1px solid rgba(245,197,66,0.36)',
+          color: '#fff7d6',
+          fontSize: 12,
+          lineHeight: 1.35,
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
+        }}>
+          Camera preview is unavailable here, so the HUD is using the mock feed.
+        </div>
+      )}
+    </Screen>
+  );
+};
+
+function HudOverlay({ state }) {
+  const setProgress = state.setProgress || 'Set 1 of 1';
+  const targetSummary = state.targetSummary || 'Ready';
+  const repProgress = state.repProgress || '--';
+  const restActive = Number.isFinite(state.restRemainingSeconds);
+  const restProgress = restActive && state.restDurationSeconds
+    ? 1 - Math.max(0, Math.min(1, state.restRemainingSeconds / state.restDurationSeconds))
+    : 0;
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, zIndex: 4, pointerEvents: 'none' }}>
+      <HudPanel style={{ top: 64, left: 18, width: 292 }}>
+        <div style={hudPanelTitleStyle()}>Workout</div>
+        <HudLine label="Exercise" value={state.exerciseName || 'Workout'} strong />
+        <HudLine label="Set" value={setProgress} />
+        <HudLine label="Target" value={targetSummary} />
+        <HudLine label="Next" value={state.nextAction || 'Follow the active set'} muted />
+      </HudPanel>
+
+      <HudPanel style={{ right: 18, bottom: 34, width: 176, opacity: 0.82 }}>
+        <div style={hudPanelTitleStyle()}>Reps</div>
+        <div style={{ fontSize: 32, fontWeight: 750, color: '#f9fff0', lineHeight: 1.05 }}>
+          {repProgress}
+        </div>
+      </HudPanel>
+
+      <div style={{
+        position: 'absolute',
+        top: 66,
+        right: 18,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        height: 32,
+        padding: '0 10px',
+        borderRadius: 9999,
+        background: 'rgba(0,0,0,0.46)',
+        border: '1px solid rgba(197,242,62,0.35)',
+        color: '#dfff7a',
+        fontSize: 11,
+        fontWeight: 750,
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
+      }}>
+        <span style={{
+          width: 8,
+          height: 8,
+          borderRadius: 9999,
+          background: '#c5f23e',
+          boxShadow: '0 0 12px rgba(197,242,62,0.95)',
+        }} />
+        Tracking
+      </div>
+
+      {restActive && (
+        <div style={{
+          position: 'absolute',
+          left: 18,
+          right: 18,
+          bottom: 38,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+        }}>
+          <div style={{
+            alignSelf: 'flex-start',
+            height: 30,
+            padding: '0 12px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            borderRadius: 9999,
+            background: 'rgba(245,197,66,0.16)',
+            border: '1px solid rgba(245,197,66,0.45)',
+            color: '#ffe58a',
+            fontSize: 12,
+            fontWeight: 750,
+          }}>
+            Rest {state.restRemainingSeconds}s
+          </div>
+          <div style={{
+            height: 8,
+            borderRadius: 9999,
+            background: 'rgba(255,255,255,0.16)',
+            overflow: 'hidden',
+            border: '1px solid rgba(255,255,255,0.12)',
+          }}>
+            <div style={{
+              width: `${Math.round(restProgress * 100)}%`,
+              height: '100%',
+              borderRadius: 9999,
+              background: '#f5c542',
+              boxShadow: '0 0 14px rgba(245,197,66,0.58)',
+              transition: 'width 600ms linear',
+            }} />
+          </div>
+        </div>
+      )}
+
+      {state.notification && (
+        <div style={{
+          position: 'absolute',
+          left: 32,
+          right: 32,
+          bottom: restActive ? 96 : 34,
+          minHeight: 44,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+          padding: '8px 12px',
+          borderRadius: 14,
+          background: 'rgba(0,0,0,0.56)',
+          border: '1px solid rgba(197,242,62,0.26)',
+          color: '#f9fff0',
+          fontSize: 13,
+          fontWeight: 700,
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
+        }}>
+          {state.notification}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HudPanel({ children, style }) {
+  return (
+    <div style={{
+      position: 'absolute',
+      padding: '13px 14px',
+      borderRadius: 12,
+      background: 'rgba(0,0,0,0.48)',
+      border: '1px solid rgba(255,255,255,0.16)',
+      boxShadow: '0 14px 42px rgba(0,0,0,0.28)',
+      backdropFilter: 'blur(14px)',
+      WebkitBackdropFilter: 'blur(14px)',
+      color: '#f9fff0',
+      ...style,
+    }}>
+      {children}
+    </div>
+  );
+}
+
+function HudLine({ label, value, strong = false, muted = false }) {
+  return (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: '68px minmax(0, 1fr)',
+      gap: 8,
+      alignItems: 'baseline',
+      marginTop: 8,
+      minWidth: 0,
+    }}>
+      <div style={{ fontSize: 10, color: 'rgba(249,255,240,0.58)', fontWeight: 700 }}>{label}</div>
+      <div style={{
+        fontSize: strong ? 16 : 12,
+        lineHeight: 1.18,
+        color: muted ? 'rgba(249,255,240,0.66)' : '#f9fff0',
+        fontWeight: strong ? 760 : 680,
+        overflowWrap: 'anywhere',
+      }}>{value}</div>
+    </div>
+  );
+}
+
+function HudMockScene({ now }) {
+  const phase = (now / 1000) % 12;
+  return (
+    <div style={{
+      position: 'absolute',
+      inset: 0,
+      background: `
+        radial-gradient(circle at ${28 + phase * 2}% 22%, rgba(197,242,62,0.14), transparent 16%),
+        linear-gradient(145deg, #181b17 0%, #0d1110 46%, #232824 100%)
+      `,
+    }}>
+      <div style={{
+        position: 'absolute',
+        left: '9%',
+        right: '9%',
+        top: '19%',
+        height: '20%',
+        borderRadius: 18,
+        background: 'linear-gradient(90deg, rgba(130,140,128,0.9), rgba(59,64,59,0.95))',
+        boxShadow: '0 22px 70px rgba(0,0,0,0.48)',
+        transform: `translateY(${Math.sin(phase) * 5}px)`,
+      }} />
+      <div style={{
+        position: 'absolute',
+        left: '18%',
+        bottom: '12%',
+        width: '64%',
+        height: '42%',
+        borderRadius: 24,
+        border: '1px solid rgba(255,255,255,0.08)',
+        background: 'linear-gradient(140deg, rgba(255,255,255,0.12), rgba(255,255,255,0.03))',
+        transform: `perspective(700px) rotateX(58deg) rotateZ(${Math.sin(phase / 2) * 1.5}deg)`,
+      }} />
+      <div style={{
+        position: 'absolute',
+        left: '36%',
+        bottom: '28%',
+        width: '28%',
+        height: '28%',
+        borderRadius: 9999,
+        background: 'rgba(22,24,22,0.92)',
+        border: '18px solid rgba(118,126,116,0.9)',
+        boxShadow: '0 12px 36px rgba(0,0,0,0.4)',
+      }} />
+      <div style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: '34%',
+        background: 'linear-gradient(0deg, rgba(0,0,0,0.58), transparent)',
+      }} />
+    </div>
+  );
+}
+
+function HudLensVignette() {
+  return (
+    <>
+      <div style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'radial-gradient(circle at center, transparent 48%, rgba(0,0,0,0.48) 100%)',
+        zIndex: 2,
+        pointerEvents: 'none',
+      }} />
+      <div style={{
+        position: 'absolute',
+        inset: 12,
+        border: '1px solid rgba(197,242,62,0.12)',
+        borderRadius: 28,
+        zIndex: 3,
+        pointerEvents: 'none',
+      }} />
+    </>
+  );
+}
+
+function deriveTrainARHudState({ programId, day, step, rest, coachResponse, now, fallback }) {
+  if (!step && fallback) {
+    const remaining = calculateRestRemaining(fallback.rest, now);
+    return {
+      ...fallback,
+      restRemainingSeconds: remaining,
+      restDurationSeconds: fallback.restDurationSeconds || fallback.rest?.durationSeconds || null,
+    };
+  }
+
+  const program = (window.PROGRAMS || []).find((item) => item.id === programId) || (window.PROGRAMS || [])[0] || {};
+  const detail = programId && window.getProgramDetail
+    ? (window.getProgramDetail(programId) || window.PROGRAM_DETAIL || { exercises: [] })
+    : (window.PROGRAM_DETAIL || { exercises: [] });
+  const selectedDay = day?.id
+    ? (detail.days || []).find((item) => item.id === day.id) || day
+    : (day || (detail.days || [])[0] || null);
+  const exercises = getDayExercises(selectedDay, detail);
+  const exerciseName = step?.exerciseName || exercises[0]?.name || program.name || 'Workout';
+  const currentExercise = exercises.find((exercise) => (
+    normalizeCoachName(exercise.name) === normalizeCoachName(exerciseName)
+  )) || exercises[0] || {};
+  const setNumber = Number.parseInt(step?.setNumber, 10) || 1;
+  const setCount = Number.parseInt(step?.setCount || currentExercise.sets, 10) || 1;
+  const repTarget = step?.repTarget || currentExercise.reps || null;
+  const loadTarget = step?.loadTarget || currentExercise.load || null;
+  const restSeconds = rest?.durationSeconds || step?.restSeconds || parseRestSecondsForCoach(currentExercise.rest);
+  const restRemainingSeconds = calculateRestRemaining(rest, now);
+
+  let nextAction = step ? 'Complete the active set' : 'Start a workout';
+  if (Number.isFinite(restRemainingSeconds)) nextAction = 'Recover and prepare';
+  else if (setNumber < setCount) nextAction = 'Advance when this set is done';
+  else if (step) nextAction = 'Finish or move to next exercise';
+
+  return {
+    exerciseName,
+    setProgress: step ? `Set ${setNumber} of ${setCount}` : 'No active set',
+    repProgress: repTarget ? `0 / ${repTarget}` : '--',
+    targetSummary: [loadTarget, repTarget ? `${repTarget} reps` : null].filter(Boolean).join(' x ') || 'Ready',
+    nextAction,
+    restRemainingSeconds,
+    restDurationSeconds: restSeconds,
+    notification: coachResponse?.response || null,
+  };
+}
+
+function buildTrainARHudStateSnapshot({ programId, day, step, rest, coachResponse }) {
+  return deriveTrainARHudState({
+    programId,
+    day,
+    step,
+    rest,
+    coachResponse,
+    now: Date.now(),
+    fallback: null,
+  });
+}
+
+function calculateRestRemaining(rest, now) {
+  if (!rest?.durationSeconds || !rest?.startedAt) return null;
+  const startedAt = new Date(rest.startedAt).getTime();
+  if (!Number.isFinite(startedAt)) return null;
+  const elapsed = Math.max(0, Math.floor((now - startedAt) / 1000));
+  return Math.max(0, Number(rest.durationSeconds) - elapsed);
+}
+
+function stopHudCameraStream(streamRef) {
+  if (!streamRef.current) return;
+  streamRef.current.getTracks().forEach((track) => track.stop());
+  streamRef.current = null;
+}
+
+function hudIconButtonStyle() {
+  return {
+    width: 38,
+    height: 38,
+    borderRadius: 9999,
+    border: '1px solid rgba(255,255,255,0.14)',
+    background: 'rgba(0,0,0,0.42)',
+    color: '#f8faf5',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backdropFilter: 'blur(14px)',
+    WebkitBackdropFilter: 'blur(14px)',
+    cursor: 'pointer',
+  };
+}
+
+function hudPanelTitleStyle() {
+  return {
+    fontSize: 10,
+    fontWeight: 800,
+    letterSpacing: 0,
+    textTransform: 'uppercase',
+    color: 'rgba(197,242,62,0.9)',
+    marginBottom: 6,
+  };
+}
+
+Object.assign(window, {
+  HudDemoScreen,
+  deriveTrainARHudState,
+  buildTrainARHudStateSnapshot,
+});

--- a/ios/screens-hud.jsx
+++ b/ios/screens-hud.jsx
@@ -18,6 +18,7 @@ const HudDemoScreen = ({
   const videoRef = React.useRef(null);
   const streamRef = React.useRef(null);
   const [cameraStatus, setCameraStatus] = React.useState('idle');
+  const [cameraError, setCameraError] = React.useState('');
   const [sourceMode, setSourceMode] = React.useState('mock');
   const [facingMode, setFacingMode] = React.useState('environment');
   const [now, setNow] = React.useState(() => Date.now());
@@ -34,6 +35,21 @@ const HudDemoScreen = ({
   });
 
   React.useEffect(() => {
+    document.documentElement.classList.add('trainar-hud-active');
+    document.body.classList.add('trainar-hud-active');
+    const root = document.getElementById('root');
+    if (root) root.classList.add('trainar-hud-active');
+    return () => {
+      document.documentElement.classList.remove('trainar-hud-active');
+      document.body.classList.remove('trainar-hud-active');
+      if (root) root.classList.remove('trainar-hud-active');
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (window.TRAINAR_NATIVE_APP && window.sendTrainARNativeCommand) {
+      window.sendTrainARNativeCommand('hudScreenActive');
+    }
     const timer = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(timer);
   }, []);
@@ -44,17 +60,56 @@ const HudDemoScreen = ({
     return () => window.removeEventListener('trainar:hud-state', onHudState);
   }, []);
 
-  React.useEffect(() => () => stopHudCameraStream(streamRef), []);
+  React.useEffect(() => {
+    const onNativeCamera = (event) => {
+      const detail = event.detail || {};
+      if (detail.status === 'streaming') {
+        setSourceMode('native-camera');
+        setCameraStatus('streaming');
+        setCameraError('');
+        return;
+      }
+      if (detail.status === 'stopped') {
+        setCameraStatus('idle');
+        setSourceMode('mock');
+        return;
+      }
+      setCameraStatus(detail.status || 'failed');
+      setCameraError(detail.message || 'Native camera preview failed.');
+      setSourceMode('mock');
+    };
+    window.addEventListener('trainar:native-camera', onNativeCamera);
+    return () => window.removeEventListener('trainar:native-camera', onNativeCamera);
+  }, []);
+
+  React.useEffect(() => () => {
+    stopHudCameraStream(streamRef);
+    if (window.TRAINAR_NATIVE_APP && window.sendTrainARNativeCommand) {
+      window.sendTrainARNativeCommand('stopHudCamera');
+    }
+  }, []);
 
   const startCamera = React.useCallback(async (nextFacingMode = facingMode) => {
+    if (window.TRAINAR_NATIVE_APP && window.sendTrainARNativeCommand) {
+      stopHudCameraStream(streamRef);
+      setCameraStatus('starting');
+      setCameraError('');
+      window.sendTrainARNativeCommand('startHudCamera', { facingMode: nextFacingMode });
+      return;
+    }
+
     if (!navigator.mediaDevices?.getUserMedia) {
       setCameraStatus('unavailable');
+      setCameraError(window.isSecureContext === false
+        ? 'Camera API is blocked because this page is not a secure context.'
+        : 'Camera API is not exposed in this WebView/browser.');
       setSourceMode('mock');
       return;
     }
 
     stopHudCameraStream(streamRef);
     setCameraStatus('starting');
+    setCameraError('');
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
@@ -76,24 +131,46 @@ const HudDemoScreen = ({
     } catch (err) {
       console.warn('HUD camera preview unavailable:', err);
       setCameraStatus('failed');
+      setCameraError(err?.message || err?.name || 'Camera preview failed.');
       setSourceMode('mock');
     }
   }, [facingMode]);
 
+  React.useEffect(() => {
+    if (window.TRAINAR_NATIVE_APP && window.sendTrainARNativeCommand) {
+      window.setTimeout(() => startCamera('environment'), 250);
+    }
+  }, [startCamera]);
+
   const useMockSource = () => {
     stopHudCameraStream(streamRef);
+    if (window.TRAINAR_NATIVE_APP && window.sendTrainARNativeCommand) {
+      window.sendTrainARNativeCommand('stopHudCamera');
+    }
     setSourceMode('mock');
     setCameraStatus('idle');
+    setCameraError('');
   };
 
   const switchCamera = () => {
     const nextIndex = (HUD_DEMO_FACING_MODES.indexOf(facingMode) + 1) % HUD_DEMO_FACING_MODES.length;
+    setFacingMode(HUD_DEMO_FACING_MODES[nextIndex]);
+    if (sourceMode === 'native-camera' && window.sendTrainARNativeCommand) {
+      window.sendTrainARNativeCommand('switchHudCamera');
+      return;
+    }
     startCamera(HUD_DEMO_FACING_MODES[nextIndex]);
   };
 
   return (
-    <Screen padTop={0} padBottom={0} style={{ background: '#050605', overflow: 'hidden' }}>
-      <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', background: '#050605' }}>
+    <Screen padTop={0} padBottom={0} style={{ background: sourceMode === 'native-camera' ? 'transparent' : '#050605', overflow: 'hidden' }}>
+      <div style={{
+        position: 'absolute',
+        inset: 0,
+        overflow: 'hidden',
+        background: sourceMode === 'native-camera' ? 'transparent' : '#050605',
+        minHeight: '100dvh',
+      }}>
         {sourceMode === 'camera' ? (
           <video
             ref={videoRef}
@@ -110,6 +187,8 @@ const HudDemoScreen = ({
               background: '#050605',
             }}
           />
+        ) : sourceMode === 'native-camera' ? (
+          <div style={{ position: 'absolute', inset: 0, background: 'transparent' }} />
         ) : (
           <HudMockScene now={now} />
         )}
@@ -120,7 +199,7 @@ const HudDemoScreen = ({
 
       <div style={{
         position: 'absolute',
-        top: 'calc(env(safe-area-inset-top, 0px) + 14px)',
+        top: 'calc(env(safe-area-inset-top, 0px) + 10px)',
         left: 14,
         right: 14,
         display: 'flex',
@@ -151,10 +230,10 @@ const HudDemoScreen = ({
             width: 7,
             height: 7,
             borderRadius: 9999,
-            background: sourceMode === 'camera' ? '#c5f23e' : '#f5c542',
-            boxShadow: sourceMode === 'camera' ? '0 0 12px rgba(197,242,62,0.8)' : '0 0 12px rgba(245,197,66,0.7)',
+            background: (sourceMode === 'camera' || sourceMode === 'native-camera') ? '#c5f23e' : '#f5c542',
+            boxShadow: (sourceMode === 'camera' || sourceMode === 'native-camera') ? '0 0 12px rgba(197,242,62,0.8)' : '0 0 12px rgba(245,197,66,0.7)',
           }} />
-          {sourceMode === 'camera' ? 'Camera HUD' : 'Mock HUD'}
+          {(sourceMode === 'camera' || sourceMode === 'native-camera') ? 'Camera HUD' : 'Mock HUD'}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           {sourceMode === 'camera' && (
@@ -162,18 +241,23 @@ const HudDemoScreen = ({
               <Icon name="rotate" size={18} />
             </button>
           )}
+          {sourceMode === 'native-camera' && (
+            <button onClick={switchCamera} className="press" aria-label="Switch camera" style={hudIconButtonStyle()}>
+              <Icon name="rotate" size={18} />
+            </button>
+          )}
           <button
-            onClick={sourceMode === 'camera' ? useMockSource : () => startCamera()}
+            onClick={(sourceMode === 'camera' || sourceMode === 'native-camera') ? useMockSource : () => startCamera()}
             className="press"
-            aria-label={sourceMode === 'camera' ? 'Use mock source' : 'Start camera'}
+            aria-label={(sourceMode === 'camera' || sourceMode === 'native-camera') ? 'Use mock source' : 'Start camera'}
             style={hudIconButtonStyle()}
           >
-            <Icon name={sourceMode === 'camera' ? 'video' : 'camera'} size={18} />
+            <Icon name={(sourceMode === 'camera' || sourceMode === 'native-camera') ? 'video' : 'camera'} size={18} />
           </button>
         </div>
       </div>
 
-      {cameraStatus === 'failed' && (
+      {(cameraStatus === 'failed' || cameraStatus === 'unavailable') && (
         <div style={{
           position: 'absolute',
           left: 18,
@@ -190,7 +274,7 @@ const HudDemoScreen = ({
           backdropFilter: 'blur(14px)',
           WebkitBackdropFilter: 'blur(14px)',
         }}>
-          Camera preview is unavailable here, so the HUD is using the mock feed.
+          {cameraError || 'Camera preview is unavailable here, so the HUD is using the mock feed.'}
         </div>
       )}
     </Screen>

--- a/ios/screens-main.jsx
+++ b/ios/screens-main.jsx
@@ -221,8 +221,10 @@ const RunningWorkoutScreen = ({
   sessionId,
   day,
   step,
+  lastLoggedSet,
   rest,
   onClose,
+  onOpenHud,
   onFinish,
   onNextSet,
   onSkipExercise,
@@ -283,6 +285,43 @@ const RunningWorkoutScreen = ({
       }}>
         <Button size="md" icon="arrow-right" onClick={onNextSet}>Next set</Button>
         <Button size="md" variant="surface" icon="chevron-right" onClick={onSkipExercise}>Skip exercise</Button>
+      </div>
+
+      {lastLoggedSet && (
+        <div style={{ padding: '0 20px 16px', flexShrink: 0 }}>
+          <div style={{
+            padding: '12px 14px',
+            borderRadius: 'var(--r-card)',
+            background: 'var(--surface-1)',
+            border: '1px solid rgba(197,242,62,0.32)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+          }}>
+            <div style={{
+              width: 28, height: 28, borderRadius: 9999,
+              background: 'var(--accent)',
+              color: 'var(--on-accent)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              flexShrink: 0,
+            }}>
+              <Icon name="check" size={14} stroke="var(--on-accent)" />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 2 }}>Last logged set</div>
+              <div style={{ fontSize: 14, fontWeight: 650, color: 'var(--text-1)' }}>
+                {lastLoggedSet.exerciseName || currentName}: {lastLoggedSet.reps ?? '-'} reps
+                {lastLoggedSet.weight != null ? ` at ${lastLoggedSet.weight} lb` : ''}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div style={{ padding: '0 20px 16px', flexShrink: 0 }}>
+        <Button size="md" variant="dark" icon="video" onClick={onOpenHud}>
+          HUD demo
+        </Button>
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto', padding: '0 20px 18px' }}>

--- a/ios/screens-past-workout.jsx
+++ b/ios/screens-past-workout.jsx
@@ -2,8 +2,24 @@
 // or when tapping a previous session from the calendar / history tab.
 // Reads from window.PAST_WORKOUT.
 
-const PastWorkoutScreen = ({ workout, onBack }) => {
+const PastWorkoutScreen = ({ workout, onBack, onDelete }) => {
   const w = workout || window.PAST_WORKOUT || {};
+  const [deleting, setDeleting] = React.useState(false);
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+
+  const deleteWorkout = async () => {
+    if (!w.id || !onDelete || deleting) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await onDelete(w.id);
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   return (
     <Screen padTop={56} padBottom={40}>
@@ -18,13 +34,51 @@ const PastWorkoutScreen = ({ workout, onBack }) => {
           color: 'var(--text-1)',
           display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
         }}><Icon name="arrow-left" size={16} /></button>
-        <button className="press" style={{
-          height: 36, padding: '0 14px', borderRadius: 9999,
-          background: 'var(--surface-1)', border: '1px solid var(--hairline)',
-          color: 'var(--text-1)', cursor: 'pointer', fontSize: 12, fontWeight: 600,
-          fontFamily: 'var(--font-sans)',
-          display: 'flex', alignItems: 'center', gap: 6,
-        }}><Icon name="upload" size={14} /> Export</button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {w.id && onDelete && confirmDelete && (
+            <button
+              onClick={() => setConfirmDelete(false)}
+              disabled={deleting}
+              className="press"
+              style={{
+                height: 36, padding: '0 12px', borderRadius: 9999,
+                background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+                color: 'var(--text-2)', cursor: deleting ? 'not-allowed' : 'pointer',
+                fontSize: 12, fontWeight: 650, fontFamily: 'var(--font-sans)',
+              }}
+            >
+              Cancel
+            </button>
+          )}
+          {w.id && onDelete && (
+            <button
+              onClick={deleteWorkout}
+              disabled={deleting}
+              className="press"
+              aria-label={confirmDelete ? 'Confirm delete workout' : 'Delete workout'}
+              style={{
+                height: 36,
+                width: confirmDelete ? 'auto' : 36,
+                padding: confirmDelete ? '0 12px' : 0,
+                borderRadius: 9999,
+                background: 'rgba(255,82,82,0.1)', border: '1px solid rgba(255,82,82,0.28)',
+                color: '#ff8a8a', cursor: deleting ? 'not-allowed' : 'pointer',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                opacity: deleting ? 0.55 : 1,
+                fontSize: 12, fontWeight: 700, fontFamily: 'var(--font-sans)',
+              }}
+            >
+              {confirmDelete ? (deleting ? 'Deleting' : 'Delete') : <Icon name="trash" size={15} />}
+            </button>
+          )}
+          <button className="press" style={{
+            height: 36, padding: '0 14px', borderRadius: 9999,
+            background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+            color: 'var(--text-1)', cursor: 'pointer', fontSize: 12, fontWeight: 600,
+            fontFamily: 'var(--font-sans)',
+            display: 'flex', alignItems: 'center', gap: 6,
+          }}><Icon name="upload" size={14} /> Export</button>
+        </div>
       </div>
 
       {/* Title + auto-tracked badge. */}

--- a/ios/screens-profile.jsx
+++ b/ios/screens-profile.jsx
@@ -5,7 +5,7 @@
 // when those wire up to a real backend they'll just need data sources, not
 // shape changes.
 
-const ProfileScreen = ({ user, glassesState = {} }) => {
+const ProfileScreen = ({ user, glassesState = {}, onEditTraining }) => {
   // Backend friend can pass in `user` directly, or we fall back to whatever
   // useAuth has stashed in localStorage.
   const fallback = (() => {
@@ -25,6 +25,8 @@ const ProfileScreen = ({ user, glassesState = {} }) => {
   const displayBattery = glassesState.battery || device?.battery_percent || 78;
   const displayName = glassesState.deviceName || device?.name || 'Mock Ray-Ban Meta';
   const isNativeBridge = Boolean(window.TRAINAR_NATIVE_APP);
+  const training = u.trainingProfile || window.TRAINAR_TRAINING_PROFILE || {};
+  const equipment = Array.isArray(training.availableEquipment) ? training.availableEquipment : [];
 
   const sendMockCommand = (type, payload = {}) => {
     if (window.sendTrainARNativeCommand && window.sendTrainARNativeCommand(type, payload)) return;
@@ -86,6 +88,46 @@ const ProfileScreen = ({ user, glassesState = {} }) => {
                 <Pill>Member · Apr 2026</Pill>
               </div>
             </div>
+          </div>
+        </Card>
+      </div>
+
+      {/* Training profile. */}
+      <div style={{ padding: '0 20px 14px' }}>
+        <div style={{
+          fontSize: 13, fontWeight: 600, color: 'var(--text-2)',
+          marginBottom: 10, padding: '0 4px',
+        }}>Training profile</div>
+        <Card>
+          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontSize: 15, fontWeight: 700, textTransform: 'capitalize' }}>
+                {String(training.trainingGoal || 'Not set').replace('_', ' ')}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 4, lineHeight: 1.35 }}>
+                {training.workoutDaysPerWeek || '-'} days/week · {training.workoutSessionMinutes || '-'} min · {training.trainingExperience || 'experience not set'}
+              </div>
+            </div>
+            <button
+              onClick={onEditTraining}
+              className="press"
+              style={{
+                width: 36, height: 36, borderRadius: 9999,
+                background: 'var(--surface-2)', border: '1px solid var(--hairline)',
+                color: 'var(--text-1)', display: 'flex',
+                alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+                flexShrink: 0,
+              }}
+              aria-label="Edit training profile"
+            ><Icon name="edit" size={15} /></button>
+          </div>
+
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 14 }}>
+            <Pill>{String(training.coachStyle || 'direct').replace('_', ' ')}</Pill>
+            <Pill>{String(training.evidencePreference || 'concise')} evidence</Pill>
+            {equipment.slice(0, 4).map((item) => (
+              <Pill key={item}>{String(item).replace('_', ' ')}</Pill>
+            ))}
           </div>
         </Card>
       </div>

--- a/ios/screens-program-detail.jsx
+++ b/ios/screens-program-detail.jsx
@@ -27,6 +27,8 @@ const ProgramViewScreen = ({
   const [name, setName] = React.useState(initialName);
   const [editing, setEditing] = React.useState(false);
   const [confirmDiscard, setConfirmDiscard] = React.useState(false);
+  const [discarding, setDiscarding] = React.useState(false);
+  const [discardError, setDiscardError] = React.useState(null);
   const inputRef = React.useRef(null);
 
   React.useEffect(() => {
@@ -68,17 +70,17 @@ const ProgramViewScreen = ({
             <Pill>Saved</Pill>
           )}
           <button
-            onClick={loadedToGlasses ? undefined : () => setConfirmDiscard(true)}
-            disabled={loadedToGlasses}
-            className={loadedToGlasses ? '' : 'press'}
+            onClick={loadedToGlasses || discarding ? undefined : () => { setDiscardError(null); setConfirmDiscard(true); }}
+            disabled={loadedToGlasses || discarding}
+            className={loadedToGlasses || discarding ? '' : 'press'}
             aria-label="Discard program"
             style={{
               width: 36, height: 36, borderRadius: 9999,
               background: 'var(--surface-1)', border: '1px solid var(--hairline)',
               color: 'var(--text-2)',
               display: 'flex', alignItems: 'center', justifyContent: 'center',
-              cursor: loadedToGlasses ? 'not-allowed' : 'pointer',
-              opacity: loadedToGlasses ? 0.4 : 1,
+              cursor: loadedToGlasses || discarding ? 'not-allowed' : 'pointer',
+              opacity: loadedToGlasses || discarding ? 0.4 : 1,
             }}
           ><Icon name="trash" size={15} /></button>
         </div>
@@ -111,25 +113,48 @@ const ProgramViewScreen = ({
               <div style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.45 }}>
                 {name} will be removed from your library. Past workout history is kept.
               </div>
+              {discardError && (
+                <div style={{ fontSize: 12, color: '#FF8A7A', lineHeight: 1.35, marginTop: 10 }}>
+                  {discardError}
+                </div>
+              )}
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               <button
-                onClick={() => { setConfirmDiscard(false); onDiscard && onDiscard(); }}
-                className="press"
+                onClick={async () => {
+                  if (!onDiscard || discarding) return;
+                  setDiscarding(true);
+                  setDiscardError(null);
+                  try {
+                    await onDiscard();
+                    setConfirmDiscard(false);
+                  } catch (err) {
+                    setDiscardError(err.message || 'Could not discard this program.');
+                  } finally {
+                    setDiscarding(false);
+                  }
+                }}
+                disabled={discarding}
+                className={discarding ? '' : 'press'}
                 style={{
                   width: '100%', padding: '14px 16px', borderRadius: 9999,
                   background: '#FF8A7A', border: 'none', color: '#1A0A07',
-                  fontSize: 15, fontWeight: 600, letterSpacing: -0.2, cursor: 'pointer',
+                  fontSize: 15, fontWeight: 600, letterSpacing: -0.2,
+                  cursor: discarding ? 'wait' : 'pointer',
+                  opacity: discarding ? 0.75 : 1,
                   fontFamily: 'var(--font-sans)',
                 }}
-              >Discard program</button>
+              >{discarding ? 'Discarding...' : 'Discard program'}</button>
               <button
-                onClick={() => setConfirmDiscard(false)}
-                className="press"
+                onClick={() => { if (!discarding) setConfirmDiscard(false); }}
+                disabled={discarding}
+                className={discarding ? '' : 'press'}
                 style={{
                   width: '100%', padding: '14px 16px', borderRadius: 9999,
                   background: 'transparent', border: '1px solid var(--hairline)', color: 'var(--text-1)',
-                  fontSize: 15, fontWeight: 500, letterSpacing: -0.2, cursor: 'pointer',
+                  fontSize: 15, fontWeight: 500, letterSpacing: -0.2,
+                  cursor: discarding ? 'not-allowed' : 'pointer',
+                  opacity: discarding ? 0.6 : 1,
                   fontFamily: 'var(--font-sans)',
                 }}
               >Keep</button>

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -251,7 +251,7 @@ const NameScreen = ({ auth, onContinue, onBack }) => {
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: 13, fontWeight: 600 }}>Quick setup</div>
               <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 2 }}>
-                Next, we'll pair your glasses. Takes about 30 seconds.
+                Next, we will tune your training profile.
               </div>
             </div>
           </Card>
@@ -268,8 +268,254 @@ const NameScreen = ({ auth, onContinue, onBack }) => {
 };
 
 // ─────────────────────────────────────────────────────────────
-// 4. Done — placeholder so the flow has somewhere to land. Real
-//    next step is glasses pairing, owned by a different ticket.
+// 4. Training profile - required lightweight personalization.
+// ─────────────────────────────────────────────────────────────
+const TrainingProfileScreen = ({ auth, onContinue, onBack }) => {
+  const existing = auth.user?.trainingProfile || {};
+  const [goal, setGoal] = React.useState(existing.trainingGoal || 'strength');
+  const [experience, setExperience] = React.useState(existing.trainingExperience || 'beginner');
+  const [days, setDays] = React.useState(existing.workoutDaysPerWeek || 3);
+  const [minutes, setMinutes] = React.useState(existing.workoutSessionMinutes || 45);
+  const [equipment, setEquipment] = React.useState(existing.availableEquipment?.length ? existing.availableEquipment : ['gym']);
+  const [coachStyle, setCoachStyle] = React.useState(existing.coachStyle || 'direct');
+  const [evidencePreference, setEvidencePreference] = React.useState(existing.evidencePreference || 'concise');
+  const [submitting, setSubmitting] = React.useState(false);
+
+  const toggleEquipment = (value) => {
+    setEquipment((current) => {
+      if (current.includes(value)) return current.filter((item) => item !== value);
+      return [...current, value];
+    });
+  };
+
+  const submit = async () => {
+    if (!goal || !experience || !days || !minutes || !equipment.length) return;
+    setSubmitting(true);
+    const ok = await auth.setTrainingProfile({
+      trainingGoal: goal,
+      trainingExperience: experience,
+      workoutDaysPerWeek: days,
+      workoutSessionMinutes: minutes,
+      availableEquipment: equipment,
+      coachStyle,
+      evidencePreference,
+      movementConstraints: existing.movementConstraints || '',
+    });
+    setSubmitting(false);
+    if (ok) onContinue();
+  };
+
+  return (
+    <Screen padTop={56} padBottom={28} style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ padding: '0 24px 18px' }}>
+        <button onClick={onBack} className="press" style={{
+          width: 40, height: 40, borderRadius: 9999, background: 'var(--surface-1)',
+          border: '1px solid var(--hairline)', color: 'var(--text-1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+          marginBottom: 22,
+        }}><Icon name="arrow-left" size={18} /></button>
+
+        <h1 style={{
+          fontSize: 29, lineHeight: 1.12, fontWeight: 600, letterSpacing: -0.7,
+          margin: 0, marginBottom: 9,
+        }}>Tune your coach</h1>
+        <p style={{ fontSize: 14, color: 'var(--text-2)', lineHeight: 1.45, margin: 0 }}>
+          These basics shape your first plans and coach answers.
+        </p>
+      </div>
+
+      <div className="no-scrollbar" style={{
+        flex: 1, overflowY: 'auto', padding: '0 24px 16px',
+        display: 'flex', flexDirection: 'column', gap: 18,
+      }}>
+        <ChoiceGroup
+          title="Goal"
+          value={goal}
+          onChange={setGoal}
+          options={[
+            ['strength', 'Strength'],
+            ['hypertrophy', 'Muscle'],
+            ['fat_loss', 'Fat loss'],
+            ['general_fitness', 'Fitness'],
+          ]}
+        />
+
+        <ChoiceGroup
+          title="Experience"
+          value={experience}
+          onChange={setExperience}
+          options={[
+            ['beginner', 'Beginner'],
+            ['intermediate', 'Intermediate'],
+            ['advanced', 'Advanced'],
+          ]}
+        />
+
+        <StepperRow
+          title="Weekly workouts"
+          value={days}
+          min={1}
+          max={7}
+          suffix="days"
+          onChange={setDays}
+        />
+
+        <StepperRow
+          title="Session length"
+          value={minutes}
+          min={20}
+          max={120}
+          step={15}
+          suffix="min"
+          onChange={setMinutes}
+        />
+
+        <MultiChoiceGroup
+          title="Equipment"
+          values={equipment}
+          onToggle={toggleEquipment}
+          options={[
+            ['bodyweight', 'Bodyweight'],
+            ['dumbbells', 'Dumbbells'],
+            ['barbell', 'Barbell'],
+            ['machines', 'Machines'],
+            ['bands', 'Bands'],
+            ['gym', 'Full gym'],
+          ]}
+        />
+
+        <ChoiceGroup
+          title="Coach style"
+          value={coachStyle}
+          onChange={setCoachStyle}
+          options={[
+            ['direct', 'Direct'],
+            ['encouraging', 'Encouraging'],
+            ['analytical', 'Analytical'],
+            ['high_energy', 'High energy'],
+          ]}
+        />
+
+        <ChoiceGroup
+          title="Evidence"
+          value={evidencePreference}
+          onChange={setEvidencePreference}
+          options={[
+            ['minimal', 'Minimal'],
+            ['concise', 'Concise'],
+            ['detailed', 'Detailed'],
+          ]}
+        />
+
+        {auth.error && (
+          <div style={{ color: '#FF8B7C', fontSize: 13, padding: '0 4px' }}>{auth.error}</div>
+        )}
+      </div>
+
+      <div style={{ padding: '0 24px' }}>
+        <Button onClick={submit} iconRight="arrow-right" disabled={submitting || !equipment.length}>
+          {submitting ? 'Saving...' : 'Continue'}
+        </Button>
+      </div>
+    </Screen>
+  );
+};
+
+const ChoiceGroup = ({ title, value, options, onChange }) => (
+  <div>
+    <div style={{
+      fontSize: 11, color: 'var(--text-3)', textTransform: 'uppercase',
+      letterSpacing: 0.4, fontWeight: 700, marginBottom: 9,
+    }}>{title}</div>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+      {options.map(([id, label]) => (
+        <button
+          key={id}
+          onClick={() => onChange(id)}
+          className="press"
+          style={choiceButtonStyle(value === id)}
+        >{label}</button>
+      ))}
+    </div>
+  </div>
+);
+
+const MultiChoiceGroup = ({ title, values, options, onToggle }) => (
+  <div>
+    <div style={{
+      fontSize: 11, color: 'var(--text-3)', textTransform: 'uppercase',
+      letterSpacing: 0.4, fontWeight: 700, marginBottom: 9,
+    }}>{title}</div>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+      {options.map(([id, label]) => (
+        <button
+          key={id}
+          onClick={() => onToggle(id)}
+          className="press"
+          style={choiceButtonStyle(values.includes(id))}
+        >{label}</button>
+      ))}
+    </div>
+  </div>
+);
+
+const StepperRow = ({ title, value, min, max, step = 1, suffix, onChange }) => (
+  <div style={{
+    minHeight: 58, borderRadius: 16, background: 'var(--surface-1)',
+    border: '1px solid var(--hairline)', padding: '0 14px',
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16,
+  }}>
+    <div>
+      <div style={{ fontSize: 13, fontWeight: 700 }}>{title}</div>
+      <div className="mono" style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 3 }}>
+        {value} {suffix}
+      </div>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <button
+        onClick={() => onChange(Math.max(min, Number(value) - step))}
+        className="press"
+        style={stepperButtonStyle}
+        aria-label={`Decrease ${title}`}
+      ><Icon name="minus" size={16} /></button>
+      <button
+        onClick={() => onChange(Math.min(max, Number(value) + step))}
+        className="press"
+        style={stepperButtonStyle}
+        aria-label={`Increase ${title}`}
+      ><Icon name="plus" size={16} /></button>
+    </div>
+  </div>
+);
+
+const choiceButtonStyle = (selected) => ({
+  minHeight: 38,
+  padding: '0 13px',
+  borderRadius: 9999,
+  border: selected ? '1px solid rgba(197,242,62,0.55)' : '1px solid var(--hairline)',
+  background: selected ? 'var(--accent-soft)' : 'var(--surface-1)',
+  color: selected ? 'var(--accent)' : 'var(--text-2)',
+  fontFamily: 'var(--font-sans)',
+  fontSize: 13,
+  fontWeight: 700,
+  cursor: 'pointer',
+});
+
+const stepperButtonStyle = {
+  width: 34,
+  height: 34,
+  borderRadius: 9999,
+  border: '1px solid var(--hairline)',
+  background: 'var(--surface-2)',
+  color: 'var(--text-1)',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+};
+
+// ─────────────────────────────────────────────────────────────
+// 5. Done — placeholder so the flow has somewhere to land.
 // ─────────────────────────────────────────────────────────────
 const DoneScreen = ({ auth, onAddProgram, onRestart }) => (
   <Screen padTop={0} padBottom={0} style={{ display: 'flex', flexDirection: 'column' }}>
@@ -300,135 +546,4 @@ const DoneScreen = ({ auth, onAddProgram, onRestart }) => (
   </Screen>
 );
 
-// ─────────────────────────────────────────────────────────────
-// 4. Pair glasses — placeholder.
-//
-// We don't actually talk to glasses yet. The whole screen is fake-timer
-// driven so the visual flow matches the design. When a real bluetooth/
-// pairing layer exists, swap the setTimeout calls for real callbacks.
-// ─────────────────────────────────────────────────────────────
-const PairScreen = ({ onContinue, onSkip, onBack }) => {
-  const [phase, setPhase] = React.useState('searching'); // searching → found → connected
-
-  // Pretend to scan for glasses, then "discover" one.
-  React.useEffect(() => {
-    const t = setTimeout(() => setPhase('found'), 1600);
-    return () => clearTimeout(t);
-  }, []);
-
-  const pair = () => {
-    setPhase('connected');
-    if (window.pairDemoDevice) {
-      window.pairDemoDevice().catch((err) => console.error('Could not save paired device:', err));
-    }
-    setTimeout(onContinue, 1100);
-  };
-
-  const connected = phase === 'connected';
-
-  return (
-    <Screen padTop={64} padBottom={32} style={{ display: 'flex', flexDirection: 'column' }}>
-      <div style={{ padding: '0 24px' }}>
-        <button onClick={onBack} className="press" style={{
-          width: 40, height: 40, borderRadius: 9999, background: 'var(--surface-1)',
-          border: '1px solid var(--hairline)', color: 'var(--text-1)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
-          marginBottom: 24,
-        }}><Icon name="arrow-left" size={18} /></button>
-
-        <h1 style={{
-          fontSize: 28, lineHeight: 1.15, fontWeight: 600, letterSpacing: -0.6,
-          margin: 0, marginBottom: 10,
-        }}>Pair your glasses</h1>
-        <p style={{ fontSize: 14, color: 'var(--text-2)', margin: 0, marginBottom: 32 }}>
-          Make sure your glasses are powered on and within 3 feet.
-        </p>
-      </div>
-
-      {/* Big concentric indicator. */}
-      <div style={{
-        flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
-        position: 'relative',
-      }}>
-        <div style={{
-          width: 240, height: 240, borderRadius: '50%',
-          border: '1px solid ' + (connected ? 'var(--accent)' : 'var(--hairline-2)'),
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          position: 'relative',
-          boxShadow: connected ? '0 0 80px rgba(197,242,62,0.5)' : 'none',
-          transition: 'all 600ms',
-        }}>
-          {phase === 'searching' && (
-            <div className="spin-ring" style={{
-              position: 'absolute', inset: -1, borderRadius: '50%',
-              border: '2px solid transparent', borderTopColor: 'var(--accent)',
-            }} />
-          )}
-          <div style={{
-            width: 130, height: 130, borderRadius: '50%',
-            background: connected ? 'var(--accent)' : 'var(--surface-1)',
-            border: '1px solid ' + (connected ? 'var(--accent)' : 'var(--hairline)'),
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            transition: 'all 400ms',
-          }}>
-            {connected
-              ? <Icon name="check"   size={56} stroke="var(--on-accent)" strokeWidth={2.5} />
-              : <Icon name="glasses" size={56} stroke="var(--text-1)"   strokeWidth={1.5} />}
-          </div>
-        </div>
-      </div>
-
-      <div style={{ padding: '0 24px 0', display: 'flex', flexDirection: 'column', gap: 10 }}>
-        {phase === 'searching' && (
-          <Card style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <div className="pulse-dot" style={{
-              width: 8, height: 8, borderRadius: 4, background: 'var(--accent)',
-            }} />
-            <div style={{ fontSize: 14, color: 'var(--text-2)' }}>Searching for nearby glasses…</div>
-          </Card>
-        )}
-
-        {phase === 'found' && (
-          <Card>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
-              <div style={{
-                width: 44, height: 44, borderRadius: 12, background: 'var(--surface-2)',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-              }}>
-                <Icon name="glasses" size={22} />
-              </div>
-              <div style={{ flex: 1 }}>
-                <div style={{ fontSize: 15, fontWeight: 600 }}>TrainAR · M2</div>
-                <div style={{
-                  fontSize: 11, color: 'var(--text-3)', marginTop: 2,
-                  fontFamily: 'var(--font-mono)',
-                }}>SN · 8E40·B7C2 · -54 dBm</div>
-              </div>
-              <Button size="sm" onClick={pair} style={{ width: 'auto' }}>Pair</Button>
-            </div>
-          </Card>
-        )}
-
-        {connected && (
-          <Card style={{
-            background: 'var(--accent-soft)', border: '1px solid rgba(197,242,62,0.3)',
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
-              <Icon name="check" size={20} stroke="var(--accent)" strokeWidth={2.5} />
-              <div style={{ fontSize: 14, color: 'var(--accent)', fontWeight: 600 }}>
-                Paired — finishing setup…
-              </div>
-            </div>
-          </Card>
-        )}
-
-        <button onClick={onSkip} className="press" style={{
-          background: 'transparent', border: 'none', color: 'var(--text-2)',
-          fontSize: 13, padding: 12, cursor: 'pointer', fontFamily: 'var(--font-sans)',
-        }}>I'll do this later</button>
-      </div>
-    </Screen>
-  );
-};
-
-Object.assign(window, { Screen, SplashScreen, AuthScreen, NameScreen, PairScreen, DoneScreen });
+Object.assign(window, { Screen, SplashScreen, AuthScreen, NameScreen, TrainingProfileScreen, DoneScreen });

--- a/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
+++ b/native-ios/TrainAR/TrainAR/AppleVoiceBridge.swift
@@ -63,6 +63,7 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         case capturingUtterance
         case awaitingReply
         case speakingReply
+        case speakingFollowUpPrompt
     }
     private var mode: Mode = .idle
 
@@ -138,9 +139,10 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         switch type {
         case "speakResponse":
             let text = (body?["text"] as? String) ?? ""
+            let continueListening = (body?["continueListening"] as? Bool) ?? false
             // Pause wake-word recognition so we don't trigger on the reply text.
             stopRecognition()
-            mode = .speakingReply
+            mode = continueListening ? .speakingFollowUpPrompt : .speakingReply
             speak(text: text)
         case "startListening":
             // Manual override — pretend the wake word just fired.
@@ -432,6 +434,8 @@ final class AppleVoiceBridge: NSObject, GlassesBridge, AVSpeechSynthesizerDelega
         Task { @MainActor in
             switch mode {
             case .acknowledgingWakeWord:
+                startUtteranceCapture()
+            case .speakingFollowUpPrompt:
                 startUtteranceCapture()
             case .speakingReply:
                 startWakeWordDetection()

--- a/native-ios/TrainAR/TrainAR/Info.plist
+++ b/native-ios/TrainAR/TrainAR/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ChatEndpointURL</key>
-	<string>http://10.27.14.236:5001/api/chat</string>
+	<string>http://10.27.10.111:5001/api/chat</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -28,6 +28,16 @@
 		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>10.27.10.111</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>10.27.14.236</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 			<key>10.27.12.116</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
@@ -56,7 +66,7 @@
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>TrainAR transcribes your voice commands on-device so the coach can act on them.</string>
 	<key>TRAINAR_WEB_URL</key>
-	<string>http://10.27.14.236:5001/ios/</string>
+	<string>http://10.27.10.111:5001/ios/</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -67,6 +77,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/native-ios/TrainAR/TrainAR/Info.plist
+++ b/native-ios/TrainAR/TrainAR/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ChatEndpointURL</key>
-	<string>http://10.27.12.116:5001/api/chat</string>
+	<string>http://10.27.14.236:5001/api/chat</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -56,7 +56,7 @@
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>TrainAR transcribes your voice commands on-device so the coach can act on them.</string>
 	<key>TRAINAR_WEB_URL</key>
-	<string>http://10.27.12.116:5001/ios/</string>
+	<string>http://10.27.14.236:5001/ios/</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/native-ios/TrainAR/TrainAR/TrainARWebView.swift
+++ b/native-ios/TrainAR/TrainAR/TrainARWebView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WebKit
+import AVFoundation
 
 struct TrainARWebView<B: GlassesBridge>: UIViewRepresentable {
     @ObservedObject var bridge: B
@@ -8,13 +9,20 @@ struct TrainARWebView<B: GlassesBridge>: UIViewRepresentable {
         Coordinator(bridge: bridge)
     }
 
-    func makeUIView(context: Context) -> WKWebView {
+    func makeUIView(context: Context) -> UIView {
         let configuration = WKWebViewConfiguration()
         configuration.userContentController.add(context.coordinator, name: "trainarNative")
         configuration.userContentController.addUserScript(Self.bootstrapScript)
 
+        let containerView = UIView()
+        containerView.backgroundColor = .black
+        context.coordinator.attachCameraPreview(to: containerView)
+
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
         webView.allowsBackForwardNavigationGestures = false
         webView.scrollView.delegate = context.coordinator
         webView.scrollView.bounces = false
@@ -24,14 +32,26 @@ struct TrainARWebView<B: GlassesBridge>: UIViewRepresentable {
         webView.scrollView.showsHorizontalScrollIndicator = false
         webView.scrollView.minimumZoomScale = 1
         webView.scrollView.maximumZoomScale = 1
+        webView.scrollView.backgroundColor = .clear
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+        ])
         context.coordinator.attach(webView)
 
         webView.load(URLRequest(url: Self.webURL))
-        return webView
+        return containerView
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {
-        context.coordinator.attach(webView)
+    func updateUIView(_ uiView: UIView, context: Context) {
+        if let webView = uiView.subviews.compactMap({ $0 as? WKWebView }).first {
+            context.coordinator.attach(webView)
+        }
+        context.coordinator.attachCameraPreview(to: uiView)
     }
 }
 
@@ -77,10 +97,16 @@ extension TrainARWebView {
     }
 }
 
-final class Coordinator<B: GlassesBridge>: NSObject, WKNavigationDelegate, WKScriptMessageHandler, UIScrollViewDelegate {
+final class Coordinator<B: GlassesBridge>: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, UIScrollViewDelegate {
     private let bridge: B
     private weak var webView: WKWebView?
+    private weak var cameraContainerView: UIView?
     private var eventTask: Task<Void, Never>?
+    private let cameraSession = AVCaptureSession()
+    private let cameraSessionQueue = DispatchQueue(label: "com.trainar.hud.camera")
+    private var cameraPreviewLayer: AVCaptureVideoPreviewLayer?
+    private var cameraPosition: AVCaptureDevice.Position = .back
+    private var cameraConfigured = false
 
     init(bridge: B) {
         self.bridge = bridge
@@ -92,10 +118,55 @@ final class Coordinator<B: GlassesBridge>: NSObject, WKNavigationDelegate, WKScr
         self.webView = webView
     }
 
+    func attachCameraPreview(to containerView: UIView) {
+        cameraContainerView = containerView
+        if cameraPreviewLayer == nil {
+            let previewLayer = AVCaptureVideoPreviewLayer(session: cameraSession)
+            previewLayer.videoGravity = .resizeAspectFill
+            previewLayer.isHidden = true
+            containerView.layer.insertSublayer(previewLayer, at: 0)
+            cameraPreviewLayer = previewLayer
+        }
+        cameraPreviewLayer?.frame = containerView.bounds
+    }
+
+    private func updatePreviewLayerFrame() {
+        guard let cameraContainerView, let cameraPreviewLayer else { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cameraPreviewLayer.frame = cameraContainerView.bounds
+        if let connection = cameraPreviewLayer.connection, connection.isVideoOrientationSupported {
+            connection.videoOrientation = currentVideoOrientation()
+        }
+        CATransaction.commit()
+    }
+
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == "trainarNative" else { return }
         guard let body = message.body as? [String: Any],
               let type = body["type"] as? String else {
+            return
+        }
+
+        if type == "startHudCamera" {
+            let payload = body["payload"] as? [String: Any]
+            let facingMode = payload?["facingMode"] as? String
+            startHudCamera(facingMode: facingMode)
+            return
+        }
+
+        if type == "stopHudCamera" {
+            stopHudCamera()
+            return
+        }
+
+        if type == "switchHudCamera" {
+            switchHudCamera()
+            return
+        }
+
+        if type == "hudScreenActive" {
+            updatePreviewLayerFrame()
             return
         }
 
@@ -106,8 +177,155 @@ final class Coordinator<B: GlassesBridge>: NSObject, WKNavigationDelegate, WKScr
         bridge.replayState()
     }
 
+    @available(iOS 15.0, *)
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        guard type == .camera || type == .cameraAndMicrophone else {
+            decisionHandler(.deny)
+            return
+        }
+
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            decisionHandler(.grant)
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async {
+                    decisionHandler(granted ? .grant : .deny)
+                }
+            }
+        case .denied, .restricted:
+            decisionHandler(.deny)
+        @unknown default:
+            decisionHandler(.prompt)
+        }
+    }
+
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         nil
+    }
+
+    func scrollViewDidLayoutSubviews(_ scrollView: UIScrollView) {
+        updatePreviewLayerFrame()
+    }
+
+    private func startHudCamera(facingMode: String?) {
+        cameraPosition = facingMode == "user" ? .front : .back
+
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            startConfiguredCamera()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        self?.startConfiguredCamera()
+                    } else {
+                        self?.emitHudCameraEvent(status: "denied", message: "Camera permission was denied.")
+                    }
+                }
+            }
+        case .denied, .restricted:
+            emitHudCameraEvent(status: "denied", message: "Camera permission is disabled for TrainAR.")
+        @unknown default:
+            emitHudCameraEvent(status: "failed", message: "Camera permission status is unknown.")
+        }
+    }
+
+    private func startConfiguredCamera() {
+        cameraSessionQueue.async { [weak self] in
+            guard let self else { return }
+            do {
+                try self.configureCameraSession(position: self.cameraPosition)
+                if !self.cameraSession.isRunning {
+                    self.cameraSession.startRunning()
+                }
+                DispatchQueue.main.async {
+                    self.cameraPreviewLayer?.isHidden = false
+                    self.updatePreviewLayerFrame()
+                    self.emitHudCameraEvent(status: "streaming", message: nil)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.emitHudCameraEvent(status: "failed", message: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func stopHudCamera() {
+        cameraSessionQueue.async { [weak self] in
+            guard let self else { return }
+            if self.cameraSession.isRunning {
+                self.cameraSession.stopRunning()
+            }
+            DispatchQueue.main.async {
+                self.cameraPreviewLayer?.isHidden = true
+                self.emitHudCameraEvent(status: "stopped", message: nil)
+            }
+        }
+    }
+
+    private func switchHudCamera() {
+        cameraPosition = cameraPosition == .back ? .front : .back
+        startConfiguredCamera()
+    }
+
+    private func configureCameraSession(position: AVCaptureDevice.Position) throws {
+        cameraSession.beginConfiguration()
+        defer { cameraSession.commitConfiguration() }
+
+        cameraSession.inputs.forEach { cameraSession.removeInput($0) }
+
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position) else {
+            throw HudCameraError.unavailable
+        }
+
+        let input = try AVCaptureDeviceInput(device: device)
+        guard cameraSession.canAddInput(input) else {
+            throw HudCameraError.cannotAddInput
+        }
+
+        cameraSession.addInput(input)
+        cameraSession.sessionPreset = cameraSession.canSetSessionPreset(.hd1280x720) ? .hd1280x720 : .high
+        cameraConfigured = true
+    }
+
+    private func emitHudCameraEvent(status: String, message: String?) {
+        let payload: [String: String] = [
+            "status": status,
+            "message": message ?? "",
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+
+        let script = """
+        window.dispatchEvent(new CustomEvent('trainar:native-camera', { detail: \(json) }));
+        """
+        webView?.evaluateJavaScript(script)
+    }
+
+    private func currentVideoOrientation() -> AVCaptureVideoOrientation {
+        guard let orientation = cameraContainerView?.window?.windowScene?.interfaceOrientation else {
+            return .portrait
+        }
+        switch orientation {
+        case .landscapeLeft:
+            return .landscapeLeft
+        case .landscapeRight:
+            return .landscapeRight
+        case .portraitUpsideDown:
+            return .portraitUpsideDown
+        default:
+            return .portrait
+        }
     }
 
     private func startForwardingEvents() {
@@ -131,5 +349,19 @@ final class Coordinator<B: GlassesBridge>: NSObject, WKNavigationDelegate, WKScr
         window.dispatchEvent(new CustomEvent('trainar:glasses', { detail: \(json) }));
         """
         webView.evaluateJavaScript(script)
+    }
+}
+
+private enum HudCameraError: LocalizedError {
+    case unavailable
+    case cannotAddInput
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "No camera is available on this device."
+        case .cannotAddInput:
+            return "Could not attach the camera to the preview session."
+        }
     }
 }

--- a/native-ios/TrainAR/TrainAR/TrainARWebView.swift
+++ b/native-ios/TrainAR/TrainAR/TrainARWebView.swift
@@ -65,7 +65,10 @@ extension TrainARWebView {
               var detail = event.detail || {};
               var text = detail.text || '';
               if (!text) return;
-              window.TrainARNative.postMessage('speakResponse', { text: text });
+              window.TrainARNative.postMessage('speakResponse', {
+                text: text,
+                continueListening: Boolean(detail.continueListening)
+              });
             });
             """,
             injectionTime: .atDocumentStart,

--- a/src/assistant/chat_route.py
+++ b/src/assistant/chat_route.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 from flask import Flask, jsonify, request
 
 from src.assistant.context_manager import CoachContextManager
+from src.assistant.coach_style import style_action_reply, style_prompt_from_context
+from src.assistant.evidence import format_evidence_context, response_sources_payload, retrieve_evidence
+from src.assistant.models import AssistantAction
 from src.assistant.service import DEFAULT_ASSISTANT_MODEL, build_openai_client, handle_action, parse_user_message
 from src.assistant.supabase_tools import SupabaseToolError, execute_supabase_action
 
@@ -23,9 +27,12 @@ LOGGER = logging.getLogger(__name__)
 TRAINER_SYSTEM_PROMPT = (
     "You are a friendly, knowledgeable personal trainer. Answer questions "
     "about exercise, form, programming, recovery, and nutrition. Keep replies "
-    "short and conversational — usually one or two sentences — because they "
+    "short and conversational - usually one or two sentences - because they "
     "will be spoken aloud through the user's glasses, not read on a screen. "
-    "Avoid bullet points, markdown, or long lists."
+    "Adapt tone to the user's coach style and evidence preference when present. "
+    "Avoid bullet points, markdown, or long lists. If evidence context is "
+    "provided, ground training claims in it and name the source briefly, such "
+    "as 'Schoenfeld et al.' Do not imply medical certainty."
 )
 
 CHAT_MODEL_ENV = "OPENAI_CHAT_MODEL"
@@ -55,6 +62,52 @@ def register_chat_route(app: Flask) -> None:
         if not text:
             return jsonify({"error": "missing 'text' in request body"}), 400
 
+        pending_action = _action_from_pending_log_confirmation(text, app_context)
+        if pending_action is not None:
+            if pending_action.action == "unknown":
+                reply = style_action_reply("Okay, I did not log it.", app_context, action_name="log_set")
+                CONTEXT_MANAGER.record_turn(session_id=session_id, user_text=text, assistant_reply=reply)
+                return jsonify(
+                    {
+                        "reply": reply,
+                        "response": reply,
+                        "mode": "action",
+                        "action": pending_action.model_dump(mode="json"),
+                        "action_result": {"cleared_pending_confirmation": True},
+                        "ui_patch": None,
+                    }
+                )
+
+            try:
+                supabase_payload = execute_supabase_action(pending_action, context=app_context, access_token=access_token)
+            except SupabaseToolError as exc:
+                LOGGER.exception("Supabase confirmed coach action failed for action=%s", pending_action.action)
+                return jsonify({"error": str(exc)}), 502
+
+            if supabase_payload is not None:
+                reply = str(supabase_payload.get("message") or "").strip()
+                ui_patch = supabase_payload.get("ui_patch")
+                action_result = dict(supabase_payload.get("action_result") or {})
+            else:
+                assistant_payload = handle_action(pending_action, context=app_context)
+                reply = str(assistant_payload.get("response") or "").strip()
+                ui_patch = _build_ui_patch(assistant_payload.get("action"), app_context)
+                action_result = {}
+
+            action_result["cleared_pending_confirmation"] = True
+            reply = style_action_reply(reply, app_context, action_name=pending_action.action)
+            CONTEXT_MANAGER.record_turn(session_id=session_id, user_text=text, assistant_reply=reply)
+            return jsonify(
+                {
+                    "reply": reply,
+                    "response": reply,
+                    "mode": "action",
+                    "action": pending_action.model_dump(mode="json"),
+                    "action_result": action_result,
+                    "ui_patch": ui_patch,
+                }
+            )
+
         try:
             action = parse_user_message(text)
         except Exception:  # noqa: BLE001 - chat can still answer if action parsing fails
@@ -72,11 +125,14 @@ def register_chat_route(app: Flask) -> None:
                 reply = str(supabase_payload.get("message") or "").strip()
                 ui_patch = supabase_payload.get("ui_patch")
                 action_result = supabase_payload.get("action_result")
+                if supabase_payload.get("ok") and not _needs_confirmation(action_result):
+                    reply = style_action_reply(reply, app_context, action_name=action.action)
             else:
                 assistant_payload = handle_action(action, context=app_context)
                 reply = str(assistant_payload.get("response") or "").strip()
                 ui_patch = _build_ui_patch(assistant_payload.get("action"), app_context)
                 action_result = None
+                reply = style_action_reply(reply, app_context, action_name=action.action)
 
             CONTEXT_MANAGER.record_turn(session_id=session_id, user_text=text, assistant_reply=reply)
             return jsonify(
@@ -105,13 +161,21 @@ def register_chat_route(app: Flask) -> None:
             )
 
         model = os.getenv(CHAT_MODEL_ENV, DEFAULT_ASSISTANT_MODEL)
+        profile = app_context.get("trainingProfile") if isinstance(app_context, dict) else None
+        evidence_sources = retrieve_evidence(text, profile=profile if isinstance(profile, dict) else None)
+        evidence_context = format_evidence_context(evidence_sources)
+        system_prompt = f"{TRAINER_SYSTEM_PROMPT}\n\n{style_prompt_from_context(app_context)}"
+        if evidence_context:
+            system_prompt = (
+                f"{system_prompt}\n\nRelevant peer-reviewed evidence:\n{evidence_context}"
+            )
 
         try:
             messages = CONTEXT_MANAGER.build_messages(
                 session_id=session_id,
                 user_text=text,
                 app_context=app_context,
-                system_prompt=TRAINER_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
             )
             completion = client.chat.completions.create(
                 model=model,
@@ -119,7 +183,7 @@ def register_chat_route(app: Flask) -> None:
                 temperature=0.7,
                 max_tokens=CHAT_MAX_TOKENS,
             )
-        except Exception:  # noqa: BLE001 — surface any OpenAI failure as a 500
+        except Exception:  # noqa: BLE001 - surface any OpenAI failure as a 500
             LOGGER.exception("OpenAI chat completion failed for text=%r", text)
             return jsonify({"error": "chat completion failed"}), 500
 
@@ -128,7 +192,14 @@ def register_chat_route(app: Flask) -> None:
             return jsonify({"error": "empty reply from model"}), 502
 
         CONTEXT_MANAGER.record_turn(session_id=session_id, user_text=text, assistant_reply=reply)
-        return jsonify({"reply": reply, "response": reply, "mode": "chat"})
+        return jsonify(
+            {
+                "reply": reply,
+                "response": reply,
+                "mode": "chat",
+                "sources": response_sources_payload(evidence_sources),
+            }
+        )
 
 
 def _build_ui_patch(action: Any, app_context: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -197,3 +268,85 @@ def _build_ui_patch(action: Any, app_context: dict[str, Any] | None) -> dict[str
         }
 
     return None
+
+
+def _needs_confirmation(action_result: Any) -> bool:
+    return isinstance(action_result, dict) and bool(action_result.get("needs_confirmation"))
+
+
+def _action_from_pending_log_confirmation(
+    text: str,
+    app_context: dict[str, Any] | None,
+) -> AssistantAction | None:
+    pending_log = _pending_log_confirmation(app_context)
+    if pending_log is None:
+        return None
+
+    if _looks_negative(text):
+        return AssistantAction(action="unknown")
+
+    if not _looks_affirmative(text):
+        return None
+
+    reps = _coerce_int(pending_log.get("reps"))
+    exercise_name = str(pending_log.get("exerciseName") or pending_log.get("exercise_name") or "").strip()
+    if not exercise_name or reps is None:
+        return AssistantAction(action="unknown")
+
+    return AssistantAction(
+        action="log_set",
+        exercise_name=exercise_name,
+        reps=reps,
+        weight=_coerce_float(pending_log.get("weight")),
+        confirmed_off_current=True,
+    )
+
+
+def _pending_log_confirmation(app_context: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(app_context, dict):
+        return None
+
+    pending_log = app_context.get("pendingLogConfirmation")
+    if not isinstance(pending_log, dict):
+        return None
+
+    if not pending_log.get("sessionId"):
+        return None
+
+    return pending_log
+
+
+def _looks_affirmative(text: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(yes|yeah|yep|correct|right|confirm|confirmed|do it|log it|that is right|that's right)\b",
+            text.lower(),
+        )
+    )
+
+
+def _looks_negative(text: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(no|nope|cancel|do not|don't|nevermind|never mind|not that|stop)\b",
+            text.lower(),
+        )
+    )
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None

--- a/src/assistant/coach_style.py
+++ b/src/assistant/coach_style.py
@@ -1,0 +1,97 @@
+"""Coach personality helpers shared by chat and deterministic tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+STYLE_INSTRUCTIONS = {
+    "direct": (
+        "Coach style: direct. Use short, plain, no-fluff language. Lead with "
+        "the action or answer."
+    ),
+    "encouraging": (
+        "Coach style: encouraging. Keep advice practical, but add a calm "
+        "confidence-building tone."
+    ),
+    "analytical": (
+        "Coach style: analytical. Give the reason behind recommendations when "
+        "space allows, and prefer precise training variables."
+    ),
+    "high_energy": (
+        "Coach style: high energy. Be punchy and upbeat while staying concise "
+        "and specific."
+    ),
+}
+
+EVIDENCE_INSTRUCTIONS = {
+    "minimal": "Evidence preference: minimal. Cite only when it directly improves the answer.",
+    "concise": "Evidence preference: concise. Mention the strongest source briefly when useful.",
+    "detailed": "Evidence preference: detailed. Include a brief rationale and source name when evidence is relevant.",
+}
+
+
+def coach_style_from_context(context: dict[str, Any] | None) -> str:
+    profile = _profile_from_context(context)
+    style = str((profile or {}).get("coachStyle") or "direct").strip().lower()
+    return style if style in STYLE_INSTRUCTIONS else "direct"
+
+
+def style_prompt_from_context(context: dict[str, Any] | None) -> str:
+    profile = _profile_from_context(context)
+    style = coach_style_from_context(context)
+    evidence = str((profile or {}).get("evidencePreference") or "concise").strip().lower()
+    evidence_line = EVIDENCE_INSTRUCTIONS.get(evidence, EVIDENCE_INSTRUCTIONS["concise"])
+    return f"{STYLE_INSTRUCTIONS[style]}\n{evidence_line}"
+
+
+def style_action_reply(message: str, context: dict[str, Any] | None, *, action_name: str | None) -> str:
+    """Apply personality to short deterministic success replies."""
+
+    clean = message.strip()
+    if not clean:
+        return clean
+
+    style = coach_style_from_context(context)
+    action = action_name or ""
+
+    if style == "direct":
+        return clean
+
+    if style == "encouraging":
+        if action in {"log_set", "advance_set", "finish_exercise"}:
+            return f"{clean} Good work."
+        if action in {"start_workout", "build_workout"}:
+            return f"{clean} We will keep it manageable."
+        if action == "finish_workout":
+            return f"{clean} Solid session."
+        return clean
+
+    if style == "analytical":
+        if action == "log_set":
+            return f"{clean} I will use that for your next progress check."
+        if action in {"start_workout", "build_workout"}:
+            return f"{clean} I matched it to your profile constraints."
+        if action == "start_rest":
+            return f"{clean} Keep the next set quality high."
+        return clean
+
+    if style == "high_energy":
+        if action == "log_set":
+            return f"{clean} Keep moving."
+        if action in {"start_workout", "build_workout"}:
+            return f"{clean} Let's go."
+        if action == "finish_workout":
+            return f"{clean} Strong finish."
+        if action == "start_rest":
+            return f"{clean} Breathe, then attack the next set."
+        return clean
+
+    return clean
+
+
+def _profile_from_context(context: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(context, dict):
+        return None
+    profile = context.get("trainingProfile")
+    return profile if isinstance(profile, dict) else None

--- a/src/assistant/context_manager.py
+++ b/src/assistant/context_manager.py
@@ -64,6 +64,29 @@ class CoachContextManager:
         records = app_context.get("personalRecords")
         sessions = app_context.get("recentSessions")
         glasses = app_context.get("glasses")
+        profile = app_context.get("trainingProfile")
+
+        if isinstance(profile, dict):
+            profile_parts = []
+            if profile.get("trainingGoal"):
+                profile_parts.append(f"goal {profile['trainingGoal']}")
+            if profile.get("trainingExperience"):
+                profile_parts.append(f"experience {profile['trainingExperience']}")
+            if profile.get("workoutDaysPerWeek"):
+                profile_parts.append(f"{profile['workoutDaysPerWeek']} days/week")
+            if profile.get("workoutSessionMinutes"):
+                profile_parts.append(f"{profile['workoutSessionMinutes']} min/session")
+            equipment = profile.get("availableEquipment")
+            if isinstance(equipment, list) and equipment:
+                profile_parts.append(f"equipment {', '.join(str(item) for item in equipment[:6])}")
+            if profile.get("coachStyle"):
+                profile_parts.append(f"coach style {profile['coachStyle']}")
+            if profile.get("evidencePreference"):
+                profile_parts.append(f"evidence preference {profile['evidencePreference']}")
+            if profile.get("movementConstraints"):
+                profile_parts.append(f"constraints {profile['movementConstraints']}")
+            if profile_parts:
+                lines.append(f"- Training profile: {'; '.join(profile_parts)}.")
 
         if isinstance(current_workout, dict):
             title = current_workout.get("title") or current_workout.get("programName") or "active workout"

--- a/src/assistant/evidence.py
+++ b/src/assistant/evidence.py
@@ -1,0 +1,209 @@
+"""Small curated exercise-science evidence library for coach grounding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+
+@dataclass(frozen=True)
+class EvidenceSource:
+    key: str
+    title: str
+    authors: str
+    journal: str
+    year: int
+    url: str
+    topics: tuple[str, ...]
+    summary: str
+    coach_note: str
+
+    @property
+    def citation(self) -> str:
+        return f"{self.authors} ({self.year})"
+
+
+EVIDENCE_LIBRARY: tuple[EvidenceSource, ...] = (
+    EvidenceSource(
+        key="schoenfeld_2017_volume",
+        title="Dose-response relationship between weekly resistance training volume and increases in muscle mass",
+        authors="Schoenfeld, Ogborn, and Krieger",
+        journal="Journal of Sports Sciences",
+        year=2017,
+        url="https://pubmed.ncbi.nlm.nih.gov/27433992/",
+        topics=("hypertrophy", "volume", "sets", "muscle", "weekly", "growth"),
+        summary=(
+            "A systematic review and meta-analysis found a dose-response pattern "
+            "between weekly resistance-training volume and muscle-mass gains."
+        ),
+        coach_note=(
+            "Use weekly hard-set volume as a main hypertrophy lever; start modestly "
+            "and add volume only when recovery and performance support it."
+        ),
+    ),
+    EvidenceSource(
+        key="schoenfeld_2016_frequency",
+        title="Effects of Resistance Training Frequency on Measures of Muscle Hypertrophy",
+        authors="Schoenfeld, Ogborn, and Krieger",
+        journal="Sports Medicine",
+        year=2016,
+        url="https://pubmed.ncbi.nlm.nih.gov/27102172/",
+        topics=("frequency", "hypertrophy", "weekly", "split", "days", "muscle"),
+        summary=(
+            "This systematic review and meta-analysis examined training frequency "
+            "as a hypertrophy variable."
+        ),
+        coach_note=(
+            "Frequency is useful for distributing weekly volume into recoverable "
+            "sessions; it should match schedule and recovery."
+        ),
+    ),
+    EvidenceSource(
+        key="acsm_2009_progression",
+        title="Progression Models in Resistance Training for Healthy Adults",
+        authors="American College of Sports Medicine",
+        journal="Medicine & Science in Sports & Exercise",
+        year=2009,
+        url="https://pubmed.ncbi.nlm.nih.gov/19204579/",
+        topics=("progression", "strength", "program", "load", "reps", "rest"),
+        summary=(
+            "This ACSM position stand outlines progression models for load, volume, "
+            "rest, and exercise selection in healthy adults."
+        ),
+        coach_note=(
+            "Progress training by changing one or two variables at a time, such as "
+            "load, reps, sets, or rest, instead of changing everything at once."
+        ),
+    ),
+    EvidenceSource(
+        key="grgic_2021_failure",
+        title="Effects of resistance training performed to repetition failure or non-failure",
+        authors="Grgic, Schoenfeld, Orazem, and Sabol",
+        journal="Journal of Sport and Health Science",
+        year=2021,
+        url="https://pubmed.ncbi.nlm.nih.gov/33497853/",
+        topics=("failure", "rir", "rpe", "intensity", "hypertrophy", "strength"),
+        summary=(
+            "This systematic review and meta-analysis compared training to failure "
+            "with stopping before failure for strength and hypertrophy."
+        ),
+        coach_note=(
+            "Most sets do not need true failure; leave a few reps in reserve for "
+            "heavy compounds and use closer-to-failure work selectively."
+        ),
+    ),
+    EvidenceSource(
+        key="grgic_2017_rest_hypertrophy",
+        title="Short versus long inter-set rest intervals and muscle hypertrophy",
+        authors="Grgic, Lazinica, Mikulic, Krieger, and Schoenfeld",
+        journal="European Journal of Sport Science",
+        year=2017,
+        url="https://pubmed.ncbi.nlm.nih.gov/28641044/",
+        topics=("rest", "interval", "hypertrophy", "sets", "fatigue"),
+        summary=(
+            "This systematic review examined short and longer inter-set rest "
+            "intervals in resistance training studies measuring hypertrophy."
+        ),
+        coach_note=(
+            "Use enough rest to keep performance high, especially on compound lifts; "
+            "short rests can still fit isolation or conditioning blocks."
+        ),
+    ),
+    EvidenceSource(
+        key="morton_2018_protein",
+        title="Effect of protein supplementation on resistance training-induced gains",
+        authors="Morton et al.",
+        journal="British Journal of Sports Medicine",
+        year=2018,
+        url="https://pubmed.ncbi.nlm.nih.gov/28698222/",
+        topics=("protein", "nutrition", "muscle", "strength", "diet", "recovery"),
+        summary=(
+            "This systematic review, meta-analysis, and meta-regression studied "
+            "protein supplementation alongside resistance exercise training."
+        ),
+        coach_note=(
+            "Protein supports training adaptations, but workout advice should still "
+            "prioritize consistent training, recovery, and total daily intake."
+        ),
+    ),
+    EvidenceSource(
+        key="pallares_2021_rom",
+        title="Effects of range of motion on resistance training adaptations",
+        authors="Pallares et al.",
+        journal="Scandinavian Journal of Medicine & Science in Sports",
+        year=2021,
+        url="https://pubmed.ncbi.nlm.nih.gov/34170576/",
+        topics=("range", "rom", "depth", "technique", "mobility", "hypertrophy", "strength"),
+        summary=(
+            "This systematic review and meta-analysis compared resistance-training "
+            "adaptations from different ranges of motion."
+        ),
+        coach_note=(
+            "Default to controlled, full usable range of motion unless the user's "
+            "anthropometrics, pain, or sport goal justify a partial range."
+        ),
+    ),
+)
+
+
+def retrieve_evidence(query: str, *, profile: dict[str, Any] | None = None, limit: int = 3) -> list[EvidenceSource]:
+    """Return the most relevant evidence records for a coach query."""
+
+    terms = set(_tokenize(query))
+    if isinstance(profile, dict):
+        profile_text = " ".join(
+            str(value)
+            for value in [
+                profile.get("trainingGoal"),
+                profile.get("trainingExperience"),
+                profile.get("coachStyle"),
+                profile.get("evidencePreference"),
+                profile.get("movementConstraints"),
+                " ".join(profile.get("availableEquipment") or []),
+            ]
+            if value
+        )
+        terms.update(_tokenize(profile_text))
+
+    scored: list[tuple[int, EvidenceSource]] = []
+    for source in EVIDENCE_LIBRARY:
+        score = len(terms.intersection(source.topics))
+        if any(topic in query.lower() for topic in source.topics):
+            score += 1
+        if score > 0:
+            scored.append((score, source))
+
+    scored.sort(key=lambda item: (-item[0], item[1].year, item[1].key))
+    return [source for _, source in scored[:limit]]
+
+
+def format_evidence_context(sources: list[EvidenceSource]) -> str:
+    """Format evidence for an LLM system message without long quotations."""
+
+    lines = []
+    for source in sources:
+        lines.append(
+            "- "
+            f"{source.citation()}, {source.journal}: {source.summary} "
+            f"Coach use: {source.coach_note} URL: {source.url}"
+        )
+    return "\n".join(lines)
+
+
+def response_sources_payload(sources: list[EvidenceSource]) -> list[dict[str, Any]]:
+    return [
+        {
+            "key": source.key,
+            "title": source.title,
+            "authors": source.authors,
+            "journal": source.journal,
+            "year": source.year,
+            "url": source.url,
+        }
+        for source in sources
+    ]
+
+
+def _tokenize(value: str) -> list[str]:
+    return [part for part in re.split(r"[^a-z0-9]+", value.lower()) if part]

--- a/src/assistant/models.py
+++ b/src/assistant/models.py
@@ -110,3 +110,10 @@ class AssistantAction(BaseModel):
         default=False,
         description="Whether the user asked to immediately start the newly created workout.",
     )
+    confirmed_off_current: bool = Field(
+        default=False,
+        description=(
+            "Internal flag set after the user confirms logging an exercise that "
+            "does not match the current workout step."
+        ),
+    )

--- a/src/assistant/prompts.py
+++ b/src/assistant/prompts.py
@@ -37,8 +37,11 @@ Use optional fields only when the user provided or clearly implied them:
 - workout_query_type
 - workout_goal
 - start_immediately
+- confirmed_off_current
 
 Do not invent unsupported fields.
+Do not set confirmed_off_current from user speech; it is reserved for internal
+confirmation replay by the app backend.
 Do not store workout state.
 Do not claim that an action was completed.
 Use advance_set when the user asks to move to the next set or next exercise

--- a/src/assistant/service.py
+++ b/src/assistant/service.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 from src.assistant.models import AssistantAction
 from src.assistant.prompts import SYSTEM_PROMPT
+from src.assistant.coach_style import style_action_reply
 from src.assistant import tools
 
 if load_dotenv is not None:
@@ -83,8 +84,9 @@ def handle_action(action: AssistantAction, *, context: dict[str, Any] | None = N
     """Execute a parsed assistant action and format the response payload."""
 
     result = _execute_action(action, context=context)
+    response = _format_response(action, result, context=context)
     return {
-        "response": _format_response(action, result, context=context),
+        "response": style_action_reply(response, context, action_name=action.action) if result.get("ok") else response,
         "action": action.model_dump(mode="json"),
     }
 

--- a/src/assistant/supabase_tools.py
+++ b/src/assistant/supabase_tools.py
@@ -20,6 +20,8 @@ from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field
 
+from src.assistant.coach_style import style_prompt_from_context
+from src.assistant.evidence import format_evidence_context, retrieve_evidence
 from src.assistant.models import AssistantAction
 from src.assistant.tools import normalize_exercise_name
 
@@ -578,17 +580,25 @@ def _generate_workout_plan(goal: str, *, context: dict[str, Any] | None) -> Gene
         return _fallback_generated_workout_plan(goal)
 
     context_summary = _workout_generation_context(context)
+    profile = context.get("trainingProfile") if isinstance(context, dict) else None
+    evidence_context = format_evidence_context(
+        retrieve_evidence(goal, profile=profile if isinstance(profile, dict) else None)
+    )
     instructions = (
         "Create a practical workout plan for the TrainAR app. Return only the "
         "structured plan. Keep it realistic for one user to perform in a gym or "
         "home setting based on the request. Prefer 4-7 exercises per day, clear "
         "set counts, rep targets, load targets, and rest times. If the user asks "
         "for one workout, create one day. If they ask for multiple days, create "
-        "that many days. Do not include medical claims."
+        "that many days. Use the user's training profile and the evidence notes "
+        "when available, but do not include medical claims."
     )
     input_text = f"User request: {goal}"
     if context_summary:
         input_text += f"\n\nAvailable user context:\n{context_summary}"
+        input_text += f"\n\nCoach style rules:\n{style_prompt_from_context(context)}"
+    if evidence_context:
+        input_text += f"\n\nRelevant peer-reviewed evidence notes:\n{evidence_context}"
 
     try:
         response = client.responses.parse(
@@ -934,6 +944,26 @@ def _workout_generation_context(context: dict[str, Any] | None) -> str:
         return ""
 
     lines: list[str] = []
+    profile = context.get("trainingProfile")
+    if isinstance(profile, dict):
+        profile_lines = []
+        mapping = [
+            ("trainingGoal", "goal"),
+            ("trainingExperience", "experience"),
+            ("workoutDaysPerWeek", "days per week"),
+            ("workoutSessionMinutes", "minutes per workout"),
+            ("coachStyle", "coach style"),
+            ("movementConstraints", "movement constraints"),
+        ]
+        for key, label in mapping:
+            if profile.get(key):
+                profile_lines.append(f"{label}: {profile[key]}")
+        equipment = profile.get("availableEquipment")
+        if isinstance(equipment, list) and equipment:
+            profile_lines.append(f"equipment: {', '.join(str(item) for item in equipment)}")
+        if profile_lines:
+            lines.append(f"Training profile: {'; '.join(profile_lines)}")
+
     records = context.get("personalRecords")
     if isinstance(records, list) and records:
         prs = []
@@ -1186,7 +1216,12 @@ def _log_set(client: SupabaseRestClient, action: AssistantAction, *, context: di
     ) if current_step else None
 
     current_step_name = _current_step_name(context)
-    if requested_exercise_name and current_step_name and not _names_compatible(requested_exercise_name, current_step_name):
+    if (
+        not action.confirmed_off_current
+        and requested_exercise_name
+        and current_step_name
+        and not _names_compatible(requested_exercise_name, current_step_name)
+    ):
         current_name = (current_exercise or {}).get("exercise_name") or current_step_name
         planned_name = (program_exercise or {}).get("exercise_name") or exercise_name
         return {
@@ -1202,7 +1237,7 @@ def _log_set(client: SupabaseRestClient, action: AssistantAction, *, context: di
             "ui_patch": None,
         }
 
-    if requested_exercise_name and current_exercise:
+    if not action.confirmed_off_current and requested_exercise_name and current_exercise:
         requested_id = str((program_exercise or {}).get("id") or "")
         current_id = str(current_exercise.get("id") or "")
         requested_matches_current = (

--- a/src/assistant/supabase_tools.py
+++ b/src/assistant/supabase_tools.py
@@ -511,6 +511,7 @@ def _build_workout(
     goal = action.workout_goal or "Build a balanced strength workout."
     plan = _generate_workout_plan(goal, context=context)
     program = _save_generated_workout_plan(client, user_id=user_id, plan=plan)
+    program_detail = _program_detail_payload(client, program)
     first_day = _program_days(client, str(program["id"]))[0] if program.get("id") else None
     first_step = _first_program_step(
         client,
@@ -522,6 +523,8 @@ def _build_workout(
         "type": "program_created",
         "programId": program.get("id"),
         "programName": program.get("title") or plan.title,
+        "program": _program_list_payload(program, program_detail),
+        "detail": program_detail,
         "day": _day_payload(first_day),
         "step": first_step,
     }
@@ -544,6 +547,8 @@ def _build_workout(
             "type": "workout_started",
             "sessionId": session.get("id"),
             "programId": program.get("id"),
+            "program": _program_list_payload(program, program_detail),
+            "detail": program_detail,
             "day": _day_payload(first_day),
             "step": first_step,
             "createdProgram": {
@@ -678,6 +683,134 @@ def _save_generated_workout_plan(
                 )
 
     return program
+
+
+def _program_list_payload(program: dict[str, Any], detail: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "id": program.get("id"),
+        "name": program.get("title"),
+        "author": program.get("author") or "Imported",
+        "weeks": program.get("weeks") or 0,
+        "daysPerWeek": program.get("days_per_week") or (detail or {}).get("dayCount") or 0,
+        "type": program.get("kind") or program.get("source_type") or "Program",
+        "color": program.get("color") or "#C5F23E",
+        "sourceLabel": program.get("source_label") or "Imported",
+        "activeWeek": program.get("active_week") or 1,
+        "progress": float(program.get("progress") or 0),
+        "description": program.get("description") or "",
+    }
+
+
+def _program_detail_payload(client: SupabaseRestClient, program: dict[str, Any]) -> dict[str, Any]:
+    program_id = str(program.get("id") or "")
+    days = _program_days(client, program_id) if program_id else []
+    day_ids = [str(day["id"]) for day in days if day.get("id")]
+
+    blocks = client.select(
+        "program_blocks",
+        {
+            "select": "id,day_id,block_number,title,execution_style",
+            "day_id": _in_filter(day_ids),
+            "order": "block_number",
+        },
+    ) if day_ids else []
+    block_ids = [str(block["id"]) for block in blocks if block.get("id")]
+
+    exercises = client.select(
+        "program_exercises",
+        {
+            "select": "id,block_id,exercise_number,exercise_name,set_count,rep_target,load_target,rest_seconds,notes,ambiguity_flags",
+            "block_id": _in_filter(block_ids),
+            "order": "exercise_number",
+        },
+    ) if block_ids else []
+
+    blocks_by_day: dict[str, list[dict[str, Any]]] = {}
+    for block in blocks:
+        blocks_by_day.setdefault(str(block.get("day_id")), []).append(block)
+
+    exercises_by_block: dict[str, list[dict[str, Any]]] = {}
+    for exercise in exercises:
+        exercises_by_block.setdefault(str(exercise.get("block_id")), []).append(exercise)
+
+    detail_days = []
+    for day in days:
+        day_blocks = []
+        for block in blocks_by_day.get(str(day.get("id")), []):
+            day_blocks.append(
+                {
+                    "id": block.get("id"),
+                    "title": block.get("title"),
+                    "executionStyle": block.get("execution_style"),
+                    "exercises": [
+                        _exercise_detail_payload(exercise)
+                        for exercise in exercises_by_block.get(str(block.get("id")), [])
+                    ],
+                }
+            )
+        detail_days.append(
+            {
+                "id": day.get("id"),
+                "title": day.get("title"),
+                "weekNumber": day.get("week_number"),
+                "dayNumber": day.get("day_number"),
+                "blocks": day_blocks,
+            }
+        )
+
+    flat_exercises = [
+        exercise
+        for day in detail_days
+        for block in day.get("blocks", [])
+        for exercise in block.get("exercises", [])
+    ]
+    return {
+        "programId": program.get("id"),
+        "name": program.get("title"),
+        "sourceType": program.get("source_type"),
+        "confidence": program.get("parse_confidence"),
+        "dayCount": len(detail_days),
+        "weeks": program.get("weeks"),
+        "totalSets": sum(_payload_set_count(exercise.get("sets")) for exercise in flat_exercises),
+        "days": detail_days,
+        "exercises": flat_exercises,
+        "canonical": program.get("canonical") or {},
+    }
+
+
+def _exercise_detail_payload(exercise: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": exercise.get("id"),
+        "name": exercise.get("exercise_name"),
+        "sets": exercise.get("set_count") if exercise.get("set_count") is not None else "-",
+        "reps": exercise.get("rep_target") or "-",
+        "load": exercise.get("load_target") or "-",
+        "rest": _format_rest_payload(exercise.get("rest_seconds")),
+        "note": " - ".join(
+            str(part)
+            for part in [exercise.get("notes"), *(exercise.get("ambiguity_flags") or [])]
+            if part
+        ),
+    }
+
+
+def _payload_set_count(value: Any) -> int:
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _format_rest_payload(seconds: Any) -> str:
+    try:
+        value = int(seconds)
+    except (TypeError, ValueError):
+        return "-"
+    if value <= 0:
+        return "-"
+    if value % 60 == 0:
+        return f"{value // 60} min"
+    return f"{value} sec"
 
 
 def _normalize_generated_workout_plan(plan: GeneratedWorkoutPlan) -> GeneratedWorkoutPlan:
@@ -1031,7 +1164,8 @@ def _query_last_workout_set(
 
 def _log_set(client: SupabaseRestClient, action: AssistantAction, *, context: dict[str, Any] | None) -> dict[str, Any]:
     session_id = _current_session_id(context)
-    exercise_name = action.exercise_name
+    requested_exercise_name = action.exercise_name
+    exercise_name = requested_exercise_name or _current_step_name(context)
     if not session_id:
         return {"ok": False, "message": "Start a workout before logging sets.", "action_result": None, "ui_patch": None}
     if not exercise_name or action.reps is None:
@@ -1043,6 +1177,58 @@ def _log_set(client: SupabaseRestClient, action: AssistantAction, *, context: di
         }
 
     program_exercise = _find_program_exercise(client, _active_program_id(context), exercise_name, day_id=_active_day_id(context))
+    current_step = _current_step(context)
+    current_exercise = _find_program_exercise(
+        client,
+        _active_program_id(context),
+        _current_step_name(context),
+        day_id=_active_day_id(context),
+    ) if current_step else None
+
+    current_step_name = _current_step_name(context)
+    if requested_exercise_name and current_step_name and not _names_compatible(requested_exercise_name, current_step_name):
+        current_name = (current_exercise or {}).get("exercise_name") or current_step_name
+        planned_name = (program_exercise or {}).get("exercise_name") or exercise_name
+        return {
+            "ok": False,
+            "message": f"You are currently on {current_name}. Did you mean to log {planned_name} instead?",
+            "action_result": {
+                "requested_exercise": planned_name,
+                "current_exercise": current_name,
+                "reps": action.reps,
+                "weight": action.weight,
+                "needs_confirmation": True,
+            },
+            "ui_patch": None,
+        }
+
+    if requested_exercise_name and current_exercise:
+        requested_id = str((program_exercise or {}).get("id") or "")
+        current_id = str(current_exercise.get("id") or "")
+        requested_matches_current = (
+            requested_id
+            and current_id
+            and requested_id == current_id
+        ) or _names_compatible(requested_exercise_name, str(current_exercise.get("exercise_name") or ""))
+        if not requested_matches_current:
+            current_name = current_exercise.get("exercise_name") or _current_step_name(context) or "the current exercise"
+            planned_name = (program_exercise or {}).get("exercise_name") or exercise_name
+            return {
+                "ok": False,
+                "message": f"You are currently on {current_name}. Did you mean to log {planned_name} instead?",
+                "action_result": {
+                    "requested_exercise": planned_name,
+                    "current_exercise": current_name,
+                    "reps": action.reps,
+                    "weight": action.weight,
+                    "needs_confirmation": True,
+                },
+                "ui_patch": None,
+            }
+
+    if program_exercise:
+        exercise_name = str(program_exercise.get("exercise_name") or exercise_name)
+
     log = _get_or_create_exercise_log(
         client,
         session_id=session_id,
@@ -1076,6 +1262,15 @@ def _log_set(client: SupabaseRestClient, action: AssistantAction, *, context: di
     if action.weight is not None:
         message += f" at {_format_number(action.weight)} pounds"
     message += "."
+    next_step = _step_after_logged_set(
+        client,
+        session_id=session_id,
+        program_id=_active_program_id(context),
+        day_id=_active_day_id(context),
+        logged_exercise_name=exercise_name,
+        context=context,
+        action=action,
+    )
     return {
         "ok": True,
         "message": message,
@@ -1085,16 +1280,42 @@ def _log_set(client: SupabaseRestClient, action: AssistantAction, *, context: di
             "sessionId": session_id,
             "exerciseName": exercise_name,
             "setNumber": set_number,
-            "step": _next_workout_step(
-                client,
-                session_id=session_id,
-                program_id=_active_program_id(context),
-                day_id=_active_day_id(context),
-                action=action,
-                context=context,
-            ),
+            "loggedSet": {
+                "exerciseName": exercise_name,
+                "setNumber": set_number,
+                "reps": action.reps,
+                "weight": action.weight,
+            },
+            "step": next_step,
         },
     }
+
+
+def _step_after_logged_set(
+    client: SupabaseRestClient,
+    *,
+    session_id: str,
+    program_id: str | None,
+    day_id: str | None,
+    logged_exercise_name: str,
+    context: dict[str, Any] | None,
+    action: AssistantAction,
+) -> dict[str, Any] | None:
+    current_step = _current_step(context)
+    current_name = _current_step_name(context)
+    if current_step and current_name:
+        if _names_compatible(logged_exercise_name, current_name):
+            return _advance_from_current_step(current_step, _program_exercises(client, program_id, day_id=day_id))
+        return current_step
+
+    return _next_workout_step(
+        client,
+        session_id=session_id,
+        program_id=program_id,
+        day_id=day_id,
+        action=action,
+        context=context,
+    )
 
 
 def _get_or_create_exercise_log(
@@ -1114,7 +1335,14 @@ def _get_or_create_exercise_log(
     )
     normalized = _normalize_name(exercise_name)
     for log in logs:
-        if _normalize_name(str(log.get("exercise_name") or "")) == normalized:
+        if (
+            _normalize_name(str(log.get("exercise_name") or "")) == normalized
+            or (
+                program_exercise
+                and log.get("program_exercise_id")
+                and str(log.get("program_exercise_id")) == str(program_exercise.get("id"))
+            )
+        ):
             return log
 
     next_number = max([int(log.get("exercise_number") or 0) for log in logs] or [0]) + 1

--- a/supabase/migrations/20260508075346_ios_backend_schema.sql
+++ b/supabase/migrations/20260508075346_ios_backend_schema.sql
@@ -1,0 +1,389 @@
+create extension if not exists pgcrypto;
+
+create schema if not exists private;
+
+create or replace function private.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create table public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  email text,
+  display_name text,
+  units text not null default 'imperial' check (units in ('imperial', 'metric')),
+  timezone text not null default 'America/Los_Angeles',
+  onboarded_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function private.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth, pg_temp
+as $$
+begin
+  insert into public.profiles (id, email, display_name, onboarded_at)
+  values (
+    new.id,
+    new.email,
+    nullif(new.raw_user_meta_data ->> 'display_name', ''),
+    case when nullif(new.raw_user_meta_data ->> 'display_name', '') is null then null else now() end
+  )
+  on conflict (id) do update
+  set email = excluded.email,
+      updated_at = now();
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function private.handle_new_user();
+
+create table public.devices (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  name text not null default 'TrainAR',
+  model text,
+  serial_number text,
+  firmware_version text,
+  battery_percent integer check (battery_percent between 0 and 100),
+  connection_status text not null default 'disconnected'
+    check (connection_status in ('connected', 'disconnected', 'pairing')),
+  last_seen_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, serial_number)
+);
+
+create table public.programs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  title text not null,
+  author text,
+  kind text,
+  source_type text,
+  source_label text,
+  source_file_path text,
+  color text not null default '#C5F23E',
+  description text,
+  weeks integer not null default 0 check (weeks >= 0),
+  days_per_week integer not null default 0 check (days_per_week >= 0),
+  active_week integer not null default 1 check (active_week >= 0),
+  progress numeric(5,4) not null default 0 check (progress >= 0 and progress <= 1),
+  parse_confidence numeric(5,4) check (parse_confidence is null or (parse_confidence >= 0 and parse_confidence <= 1)),
+  canonical jsonb not null default '{}'::jsonb,
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.program_days (
+  id uuid primary key default gen_random_uuid(),
+  program_id uuid not null references public.programs(id) on delete cascade,
+  week_number integer not null default 1 check (week_number >= 1),
+  day_number integer not null check (day_number >= 1),
+  title text not null,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (program_id, week_number, day_number)
+);
+
+create table public.program_blocks (
+  id uuid primary key default gen_random_uuid(),
+  day_id uuid not null references public.program_days(id) on delete cascade,
+  block_number integer not null check (block_number >= 1),
+  title text not null default 'Main',
+  execution_style text not null default 'sequential',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (day_id, block_number)
+);
+
+create table public.program_exercises (
+  id uuid primary key default gen_random_uuid(),
+  block_id uuid not null references public.program_blocks(id) on delete cascade,
+  exercise_number integer not null check (exercise_number >= 1),
+  exercise_name text not null,
+  set_count integer check (set_count is null or set_count >= 0),
+  rep_target text,
+  load_target text,
+  rest_seconds integer check (rest_seconds is null or rest_seconds >= 0),
+  notes text,
+  ambiguity_flags text[] not null default '{}',
+  raw jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (block_id, exercise_number)
+);
+
+create table public.workout_sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  program_id uuid references public.programs(id) on delete set null,
+  device_id uuid references public.devices(id) on delete set null,
+  title text not null,
+  status text not null default 'planned'
+    check (status in ('planned', 'in_progress', 'completed', 'abandoned')),
+  started_at timestamptz,
+  finished_at timestamptz,
+  duration_seconds integer check (duration_seconds is null or duration_seconds >= 0),
+  total_volume numeric(12,2) not null default 0 check (total_volume >= 0),
+  total_sets integer not null default 0 check (total_sets >= 0),
+  avg_rpe numeric(4,2) check (avg_rpe is null or (avg_rpe >= 0 and avg_rpe <= 10)),
+  auto_tracked_ratio numeric(5,4) check (auto_tracked_ratio is null or (auto_tracked_ratio >= 0 and auto_tracked_ratio <= 1)),
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.workout_exercise_logs (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.workout_sessions(id) on delete cascade,
+  program_exercise_id uuid references public.program_exercises(id) on delete set null,
+  exercise_number integer not null check (exercise_number >= 1),
+  exercise_name text not null,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (session_id, exercise_number)
+);
+
+create table public.workout_sets (
+  id uuid primary key default gen_random_uuid(),
+  exercise_log_id uuid not null references public.workout_exercise_logs(id) on delete cascade,
+  set_number integer not null check (set_number >= 1),
+  reps integer check (reps is null or reps >= 0),
+  load_value numeric(10,2) check (load_value is null or load_value >= 0),
+  load_unit text not null default 'lb' check (load_unit in ('lb', 'kg', 'bodyweight', 'other')),
+  rpe numeric(4,2) check (rpe is null or (rpe >= 0 and rpe <= 10)),
+  status text not null default 'auto' check (status in ('auto', 'manual')),
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (exercise_log_id, set_number)
+);
+
+create table public.personal_records (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  session_id uuid references public.workout_sessions(id) on delete set null,
+  exercise_name text not null,
+  record_type text not null default 'estimated_1rm',
+  value numeric(12,2) not null,
+  unit text not null default 'lb',
+  achieved_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index profiles_email_idx on public.profiles (email);
+create index devices_user_id_idx on public.devices (user_id);
+create index programs_user_id_created_at_idx on public.programs (user_id, created_at desc);
+create index program_days_program_id_idx on public.program_days (program_id);
+create index program_blocks_day_id_idx on public.program_blocks (day_id);
+create index program_exercises_block_id_idx on public.program_exercises (block_id);
+create index workout_sessions_user_id_started_at_idx on public.workout_sessions (user_id, started_at desc nulls last, created_at desc);
+create index workout_sessions_program_id_idx on public.workout_sessions (program_id);
+create index workout_exercise_logs_session_id_idx on public.workout_exercise_logs (session_id);
+create index workout_sets_exercise_log_id_idx on public.workout_sets (exercise_log_id);
+create index personal_records_user_id_achieved_at_idx on public.personal_records (user_id, achieved_at desc);
+
+create trigger profiles_set_updated_at
+before update on public.profiles
+for each row execute function private.set_updated_at();
+
+create trigger devices_set_updated_at
+before update on public.devices
+for each row execute function private.set_updated_at();
+
+create trigger programs_set_updated_at
+before update on public.programs
+for each row execute function private.set_updated_at();
+
+create trigger program_days_set_updated_at
+before update on public.program_days
+for each row execute function private.set_updated_at();
+
+create trigger program_blocks_set_updated_at
+before update on public.program_blocks
+for each row execute function private.set_updated_at();
+
+create trigger program_exercises_set_updated_at
+before update on public.program_exercises
+for each row execute function private.set_updated_at();
+
+create trigger workout_sessions_set_updated_at
+before update on public.workout_sessions
+for each row execute function private.set_updated_at();
+
+create trigger workout_exercise_logs_set_updated_at
+before update on public.workout_exercise_logs
+for each row execute function private.set_updated_at();
+
+create trigger workout_sets_set_updated_at
+before update on public.workout_sets
+for each row execute function private.set_updated_at();
+
+alter table public.profiles enable row level security;
+alter table public.devices enable row level security;
+alter table public.programs enable row level security;
+alter table public.program_days enable row level security;
+alter table public.program_blocks enable row level security;
+alter table public.program_exercises enable row level security;
+alter table public.workout_sessions enable row level security;
+alter table public.workout_exercise_logs enable row level security;
+alter table public.workout_sets enable row level security;
+alter table public.personal_records enable row level security;
+
+grant usage on schema public to authenticated;
+grant select, insert, update, delete on all tables in schema public to authenticated;
+
+create policy "profiles_select_own"
+on public.profiles for select
+to authenticated
+using ((select auth.uid()) is not null and id = (select auth.uid()));
+
+create policy "profiles_update_own"
+on public.profiles for update
+to authenticated
+using (id = (select auth.uid()))
+with check (id = (select auth.uid()));
+
+create policy "devices_crud_own"
+on public.devices for all
+to authenticated
+using (user_id = (select auth.uid()))
+with check (user_id = (select auth.uid()));
+
+create policy "programs_crud_own"
+on public.programs for all
+to authenticated
+using (user_id = (select auth.uid()))
+with check (user_id = (select auth.uid()));
+
+create policy "program_days_crud_own"
+on public.program_days for all
+to authenticated
+using (
+  exists (
+    select 1 from public.programs p
+    where p.id = program_days.program_id
+      and p.user_id = (select auth.uid())
+  )
+)
+with check (
+  exists (
+    select 1 from public.programs p
+    where p.id = program_days.program_id
+      and p.user_id = (select auth.uid())
+  )
+);
+
+create policy "program_blocks_crud_own"
+on public.program_blocks for all
+to authenticated
+using (
+  exists (
+    select 1
+    from public.program_days d
+    join public.programs p on p.id = d.program_id
+    where d.id = program_blocks.day_id
+      and p.user_id = (select auth.uid())
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.program_days d
+    join public.programs p on p.id = d.program_id
+    where d.id = program_blocks.day_id
+      and p.user_id = (select auth.uid())
+  )
+);
+
+create policy "program_exercises_crud_own"
+on public.program_exercises for all
+to authenticated
+using (
+  exists (
+    select 1
+    from public.program_blocks b
+    join public.program_days d on d.id = b.day_id
+    join public.programs p on p.id = d.program_id
+    where b.id = program_exercises.block_id
+      and p.user_id = (select auth.uid())
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.program_blocks b
+    join public.program_days d on d.id = b.day_id
+    join public.programs p on p.id = d.program_id
+    where b.id = program_exercises.block_id
+      and p.user_id = (select auth.uid())
+  )
+);
+
+create policy "workout_sessions_crud_own"
+on public.workout_sessions for all
+to authenticated
+using (user_id = (select auth.uid()))
+with check (user_id = (select auth.uid()));
+
+create policy "workout_exercise_logs_crud_own"
+on public.workout_exercise_logs for all
+to authenticated
+using (
+  exists (
+    select 1 from public.workout_sessions s
+    where s.id = workout_exercise_logs.session_id
+      and s.user_id = (select auth.uid())
+  )
+)
+with check (
+  exists (
+    select 1 from public.workout_sessions s
+    where s.id = workout_exercise_logs.session_id
+      and s.user_id = (select auth.uid())
+  )
+);
+
+create policy "workout_sets_crud_own"
+on public.workout_sets for all
+to authenticated
+using (
+  exists (
+    select 1
+    from public.workout_exercise_logs l
+    join public.workout_sessions s on s.id = l.session_id
+    where l.id = workout_sets.exercise_log_id
+      and s.user_id = (select auth.uid())
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.workout_exercise_logs l
+    join public.workout_sessions s on s.id = l.session_id
+    where l.id = workout_sets.exercise_log_id
+      and s.user_id = (select auth.uid())
+  )
+);
+
+create policy "personal_records_crud_own"
+on public.personal_records for all
+to authenticated
+using (user_id = (select auth.uid()))
+with check (user_id = (select auth.uid()));;

--- a/supabase/migrations/20260508075752_ios_backend_advisor_fixes.sql
+++ b/supabase/migrations/20260508075752_ios_backend_advisor_fixes.sql
@@ -1,0 +1,21 @@
+create or replace function private.set_updated_at()
+returns trigger
+language plpgsql
+set search_path = pg_catalog, pg_temp
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create index if not exists workout_sessions_device_id_idx
+on public.workout_sessions (device_id);
+
+create index if not exists workout_exercise_logs_program_exercise_id_idx
+on public.workout_exercise_logs (program_exercise_id);
+
+create index if not exists personal_records_session_id_idx
+on public.personal_records (session_id);
+
+revoke execute on function public.rls_auto_enable() from anon, authenticated;;

--- a/supabase/migrations/20260508075824_revoke_public_rls_auto_enable.sql
+++ b/supabase/migrations/20260508075824_revoke_public_rls_auto_enable.sql
@@ -1,0 +1,1 @@
+revoke execute on function public.rls_auto_enable() from public, anon, authenticated;;

--- a/supabase/migrations/20260601081225_training_profile_and_evidence_preferences.sql
+++ b/supabase/migrations/20260601081225_training_profile_and_evidence_preferences.sql
@@ -1,0 +1,28 @@
+alter table public.profiles
+  add column if not exists training_goal text,
+  add column if not exists training_experience text,
+  add column if not exists workout_days_per_week integer check (workout_days_per_week is null or workout_days_per_week between 1 and 7),
+  add column if not exists workout_session_minutes integer check (workout_session_minutes is null or workout_session_minutes between 10 and 240),
+  add column if not exists available_equipment text[] not null default '{}',
+  add column if not exists coach_style text not null default 'direct',
+  add column if not exists evidence_preference text not null default 'concise',
+  add column if not exists movement_constraints text,
+  add column if not exists training_onboarded_at timestamptz;
+
+alter table public.profiles
+  drop constraint if exists profiles_training_experience_check,
+  add constraint profiles_training_experience_check
+    check (
+      training_experience is null
+      or training_experience in ('beginner', 'intermediate', 'advanced')
+    );
+
+alter table public.profiles
+  drop constraint if exists profiles_coach_style_check,
+  add constraint profiles_coach_style_check
+    check (coach_style in ('direct', 'encouraging', 'analytical', 'high_energy'));
+
+alter table public.profiles
+  drop constraint if exists profiles_evidence_preference_check,
+  add constraint profiles_evidence_preference_check
+    check (evidence_preference in ('minimal', 'concise', 'detailed'));

--- a/tests/assistant/test_service.py
+++ b/tests/assistant/test_service.py
@@ -1,4 +1,5 @@
 from src.assistant.service import handle_message, parse_user_message
+from src.assistant.chat_route import _action_from_pending_log_confirmation
 from src.assistant.models import AssistantAction
 from src.assistant.supabase_tools import (
     _advance_from_current_step,
@@ -29,6 +30,18 @@ def test_handle_message_gets_squat_pr_with_local_fallback(monkeypatch):
     assert payload["response"] == "Your back squat PR is 315 pounds for 2 reps."
     assert payload["action"]["action"] == "get_pr"
     assert payload["action"]["exercise_name"] == "back squat"
+
+
+def test_handle_message_styles_deterministic_reply(monkeypatch):
+    monkeypatch.setattr("src.assistant.service.build_openai_client", lambda: None)
+
+    payload = handle_message(
+        "Rest 90 seconds",
+        context={"trainingProfile": {"coachStyle": "high_energy"}},
+    )
+
+    assert payload["response"] == "Starting a 90-second rest. Breathe, then attack the next set."
+    assert payload["action"]["action"] == "start_rest"
 
 
 def test_handle_message_reads_pr_from_context(monkeypatch):
@@ -434,6 +447,104 @@ def test_log_set_asks_before_logging_unplanned_off_current_exercise():
     assert result["action_result"]["needs_confirmation"] is True
     assert result["action_result"]["requested_exercise"] == "backquats"
     assert "You are currently on Hammer Curl" in result["message"]
+
+
+def test_log_set_confirmed_off_current_logs_and_preserves_current_step():
+    class FakeClient:
+        def __init__(self):
+            self.inserted_logs = []
+
+        def select(self, table, params):
+            if table == "program_days":
+                return [{"id": "day-1"}]
+            if table == "program_blocks":
+                return [{"id": "block-1", "day_id": "day-1", "block_number": 1}]
+            if table == "program_exercises":
+                return [
+                    {"id": "exercise-1", "block_id": "block-1", "exercise_number": 1, "exercise_name": "Hammer Curl", "set_count": 3},
+                ]
+            if table == "workout_exercise_logs":
+                return []
+            if table == "workout_sets":
+                return []
+            if table == "workout_sessions":
+                return [{"id": "session-1", "total_sets": 0, "total_volume": 0}]
+            return []
+
+        def insert(self, table, payload):
+            if table == "workout_exercise_logs":
+                row = {"id": "log-1", **payload}
+                self.inserted_logs.append(row)
+                return row
+            if table == "workout_sets":
+                return {"id": "set-1", **payload}
+            raise AssertionError(table)
+
+        def update(self, table, filters, payload):
+            return {"id": "session-1", **payload}
+
+    client = FakeClient()
+    result = _log_set(
+        client,
+        AssistantAction(
+            action="log_set",
+            exercise_name="backquats",
+            reps=5,
+            weight=225,
+            confirmed_off_current=True,
+        ),
+        context={
+            "activeProgramId": "program-1",
+            "currentWorkout": {
+                "sessionId": "session-1",
+                "step": {"exerciseName": "Hammer Curl", "setNumber": 2, "setCount": 3},
+            },
+        },
+    )
+
+    assert result["ok"] is True
+    assert result["ui_patch"]["loggedSet"]["exerciseName"] == "backquats"
+    assert result["ui_patch"]["step"]["exerciseName"] == "Hammer Curl"
+    assert result["ui_patch"]["step"]["setNumber"] == 2
+    assert client.inserted_logs[0]["exercise_name"] == "backquats"
+
+
+def test_pending_log_confirmation_yes_replays_confirmed_log_action():
+    action = _action_from_pending_log_confirmation(
+        "yes log it",
+        {
+            "pendingLogConfirmation": {
+                "sessionId": "session-1",
+                "exerciseName": "Back Squat",
+                "reps": 5,
+                "weight": 225,
+            },
+        },
+    )
+
+    assert action is not None
+    assert action.action == "log_set"
+    assert action.exercise_name == "Back Squat"
+    assert action.reps == 5
+    assert action.weight == 225
+    assert action.confirmed_off_current is True
+
+
+def test_pending_log_confirmation_no_clears_without_logging():
+    action = _action_from_pending_log_confirmation(
+        "no cancel that",
+        {
+            "pendingLogConfirmation": {
+                "sessionId": "session-1",
+                "exerciseName": "Back Squat",
+                "reps": 5,
+                "weight": 225,
+            },
+        },
+    )
+
+    assert action is not None
+    assert action.action == "unknown"
 
 
 def test_log_set_advances_from_current_step_not_existing_logs():

--- a/tests/assistant/test_service.py
+++ b/tests/assistant/test_service.py
@@ -3,6 +3,7 @@ from src.assistant.models import AssistantAction
 from src.assistant.supabase_tools import (
     _advance_from_current_step,
     _get_rep_record,
+    _log_set,
     _query_history,
     _query_workout,
     _resolve_program_day,
@@ -325,3 +326,165 @@ def test_skip_exercise_moves_to_next_program_exercise():
 
     assert result["ok"] is True
     assert result["ui_patch"]["step"]["exerciseName"] == "Lat Pulldown"
+
+
+def test_log_set_uses_planned_exercise_name_for_similar_request():
+    class FakeClient:
+        def __init__(self):
+            self.inserted_logs = []
+            self.inserted_sets = []
+
+        def select(self, table, params):
+            if table == "program_days":
+                return [{"id": "day-1"}]
+            if table == "program_blocks":
+                return [{"id": "block-1", "day_id": "day-1", "block_number": 1}]
+            if table == "program_exercises":
+                return [
+                    {"id": "exercise-1", "block_id": "block-1", "exercise_number": 1, "exercise_name": "Bench Press", "set_count": 3},
+                ]
+            if table == "workout_exercise_logs":
+                return []
+            if table == "workout_sets":
+                return []
+            if table == "workout_sessions":
+                return [{"id": "session-1", "total_sets": 0, "total_volume": 0}]
+            return []
+
+        def insert(self, table, payload):
+            if table == "workout_exercise_logs":
+                row = {"id": "log-1", **payload}
+                self.inserted_logs.append(row)
+                return row
+            if table == "workout_sets":
+                row = {"id": "set-1", **payload}
+                self.inserted_sets.append(row)
+                return row
+            raise AssertionError(table)
+
+        def update(self, table, filters, payload):
+            return {"id": "session-1", **payload}
+
+    client = FakeClient()
+    result = _log_set(
+        client,
+        AssistantAction(action="log_set", exercise_name="bench", reps=5, weight=185),
+        context={
+            "activeProgramId": "program-1",
+            "currentWorkout": {"sessionId": "session-1", "step": {"exerciseName": "Bench Press"}},
+        },
+    )
+
+    assert result["ok"] is True
+    assert result["ui_patch"]["exerciseName"] == "Bench Press"
+    assert client.inserted_logs[0]["exercise_name"] == "Bench Press"
+
+
+def test_log_set_asks_before_logging_different_planned_exercise():
+    class FakeClient:
+        def select(self, table, params):
+            if table == "program_days":
+                return [{"id": "day-1"}]
+            if table == "program_blocks":
+                return [{"id": "block-1", "day_id": "day-1", "block_number": 1}]
+            if table == "program_exercises":
+                return [
+                    {"id": "exercise-1", "block_id": "block-1", "exercise_number": 1, "exercise_name": "Bench Press", "set_count": 3},
+                    {"id": "exercise-2", "block_id": "block-1", "exercise_number": 2, "exercise_name": "Back Squat", "set_count": 3},
+                ]
+            return []
+
+    result = _log_set(
+        FakeClient(),
+        AssistantAction(action="log_set", exercise_name="squat", reps=5, weight=225),
+        context={
+            "activeProgramId": "program-1",
+            "currentWorkout": {"sessionId": "session-1", "step": {"exerciseName": "Bench Press"}},
+        },
+    )
+
+    assert result["ok"] is False
+    assert result["action_result"]["needs_confirmation"] is True
+    assert "Did you mean to log Back Squat instead?" in result["message"]
+
+
+def test_log_set_asks_before_logging_unplanned_off_current_exercise():
+    class FakeClient:
+        def select(self, table, params):
+            if table == "program_days":
+                return [{"id": "day-1"}]
+            if table == "program_blocks":
+                return [{"id": "block-1", "day_id": "day-1", "block_number": 1}]
+            if table == "program_exercises":
+                return [
+                    {"id": "exercise-1", "block_id": "block-1", "exercise_number": 1, "exercise_name": "Hammer Curl", "set_count": 3},
+                ]
+            return []
+
+    result = _log_set(
+        FakeClient(),
+        AssistantAction(action="log_set", exercise_name="backquats", reps=5, weight=225),
+        context={
+            "activeProgramId": "program-1",
+            "currentWorkout": {"sessionId": "session-1", "step": {"exerciseName": "Hammer Curl"}},
+        },
+    )
+
+    assert result["ok"] is False
+    assert result["action_result"]["needs_confirmation"] is True
+    assert result["action_result"]["requested_exercise"] == "backquats"
+    assert "You are currently on Hammer Curl" in result["message"]
+
+
+def test_log_set_advances_from_current_step_not_existing_logs():
+    class FakeClient:
+        def __init__(self):
+            self.inserted_logs = []
+
+        def select(self, table, params):
+            if table == "program_days":
+                return [{"id": "day-1"}]
+            if table == "program_blocks":
+                return [{"id": "block-1", "day_id": "day-1", "block_number": 1}]
+            if table == "program_exercises":
+                return [
+                    {"id": "exercise-1", "block_id": "block-1", "exercise_number": 1, "exercise_name": "Bench Press", "set_count": 3},
+                    {"id": "exercise-2", "block_id": "block-1", "exercise_number": 2, "exercise_name": "Hammer Curl", "set_count": 3},
+                ]
+            if table == "workout_exercise_logs":
+                return [
+                    {"id": "off-plan-log", "exercise_number": 1, "exercise_name": "Back Squat"},
+                ]
+            if table == "workout_sets":
+                return []
+            if table == "workout_sessions":
+                return [{"id": "session-1", "total_sets": 1, "total_volume": 225}]
+            return []
+
+        def insert(self, table, payload):
+            if table == "workout_exercise_logs":
+                row = {"id": "log-2", **payload}
+                self.inserted_logs.append(row)
+                return row
+            if table == "workout_sets":
+                return {"id": "set-2", **payload}
+            raise AssertionError(table)
+
+        def update(self, table, filters, payload):
+            return {"id": "session-1", **payload}
+
+    result = _log_set(
+        FakeClient(),
+        AssistantAction(action="log_set", exercise_name="hammer curl", reps=10, weight=25),
+        context={
+            "activeProgramId": "program-1",
+            "currentWorkout": {
+                "sessionId": "session-1",
+                "step": {"exerciseName": "Hammer Curl", "setNumber": 2, "setCount": 3},
+            },
+        },
+    )
+
+    assert result["ok"] is True
+    assert result["ui_patch"]["step"]["exerciseName"] == "Hammer Curl"
+    assert result["ui_patch"]["step"]["setNumber"] == 3


### PR DESCRIPTION
Fixed generated workout flow so newly created workouts appear immediately and open the correct program instead of the previous most-recent one.
Added immediate response for long tasks like building/generating workouts.
Added follow-up listening when the coach response is a question.
Fixed discard program so it actually archives in Supabase and updates the UI.
Hardened set logging:
Uses exact planned exercise names.
Asks for confirmation before logging an off-current exercise.
Preserves the current workout step after confirmed off-plan logging.
Shows the last logged set in the running workout UI.
Fixed workout finish flow:
Opens the workout that was just completed.
Computes totals from actual logged sets.
Does not return to the old active workout screen.
Fixed calendar day behavior so multiple workouts on the same day can be selected.
Added HUD screen wiring and native HUD state updates.
Added native follow-up listening support in AppleVoiceBridge.
Added Meta glasses prep as meta-wearables-dat-ios gitlink.
Added regression tests for workout logging behavior.

note - all HUD stuff needs more work and SDK integration
