### PR TITLE
Redesign signup, training program, and voice coach to match Claude Design

### DIFF
--- a/ios/app.jsx
+++ b/ios/app.jsx
@@ -191,6 +191,9 @@ function App() {
     lastEvent: window.TRAINAR_GLASSES_STATE?.lastEvent ?? null,
   }));
   const [coachResponse, setCoachResponse] = React.useState(null);
+  // What the coach last heard — shown in the slim capsule while it's
+  // listening / thinking, before the spoken reply lands.
+  const [coachTranscript, setCoachTranscript] = React.useState('');
   // True from wakeWordDetected → coach-response arrival. Drives the green
   // "I'm in a coach turn" border around the whole app surface.
   const [wakeActive, setWakeActive] = React.useState(false);
@@ -434,7 +437,10 @@ function App() {
       const transcript = String(detail.payload?.transcript || '').toLowerCase();
 
       if (detail.type === 'wakeWordDetected') {
+        // Fresh turn: clear any lingering reply and show the listening capsule.
         setWakeActive(true);
+        setCoachTranscript('');
+        setCoachResponse(null);
         return;
       }
 
@@ -443,12 +449,16 @@ function App() {
       if (window.askTrainARCoach && transcript) {
         const clientTurnId = coachTurnIdRef.current + 1;
         coachTurnIdRef.current = clientTurnId;
+        // Show what was heard, then a "thinking" capsule while the coach works.
+        setWakeActive(true);
+        setCoachTranscript(transcript);
         if (shouldAcknowledgeLongCoachTask(transcript)) {
-          setWakeActive(true);
           setCoachResponse({ response: 'Working on it.', processing: true });
           window.dispatchEvent(new CustomEvent('trainar:speak', {
             detail: { text: 'Working on it.' },
           }));
+        } else {
+          setCoachResponse({ processing: true });
         }
         const currentProgramId = activeProgramIdRef.current;
         const currentSessionId = activeSessionIdRef.current;
@@ -951,11 +961,24 @@ function App() {
       {showTabBar && (
         <TabBar active={activeTab} live={loadedToGlasses} onTab={switchTab} />
       )}
-      {screen !== 'hud' && coachResponse?.response && (
-        <CoachOverlay
-          response={coachResponse.response}
-          sources={coachResponse.sources || []}
-          onClose={() => setCoachResponse(null)}
+      {screen !== 'hud' && (wakeActive || coachResponse?.response || coachResponse?.processing) && (
+        <CoachCapsule
+          state={
+            coachResponse?.response && !coachResponse?.processing
+              ? 'result'
+              : (coachResponse?.processing ? 'thinking' : 'listening')
+          }
+          transcript={coachTranscript}
+          result={
+            coachResponse?.response && !coachResponse?.processing
+              ? {
+                  text: coachResponse.response,
+                  kind: (coachResponse.action || coachResponse.uiPatch) ? 'action' : 'info',
+                }
+              : null
+          }
+          sources={coachResponse?.sources || []}
+          onClose={() => { setCoachResponse(null); setCoachTranscript(''); setWakeActive(false); }}
         />
       )}
       {wakeActive && <WakeListeningBorder isNativeApp={isNativeApp} />}
@@ -1011,82 +1034,4 @@ const WakeListeningBorder = ({ isNativeApp }) => (
       zIndex: 9,
     }}
   />
-);
-
-const CoachOverlay = ({ response, sources = [], onClose }) => (
-  <div style={{
-    position: 'absolute',
-    left: 18,
-    right: 18,
-    bottom: 86,
-    zIndex: 8,
-    padding: 14,
-    borderRadius: 18,
-    background: 'rgba(20, 24, 18, 0.94)',
-    border: '1px solid rgba(197,242,62,0.24)',
-    boxShadow: '0 12px 32px rgba(0,0,0,0.45)',
-    display: 'flex',
-    gap: 12,
-    alignItems: 'flex-start',
-  }}>
-    <div style={{
-      width: 30,
-      height: 30,
-      borderRadius: 15,
-      flexShrink: 0,
-      background: 'var(--accent-soft)',
-      color: 'var(--accent)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-    }}>
-      <Icon name="sparkle" size={16} />
-    </div>
-    <div style={{ flex: 1, minWidth: 0 }}>
-      <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--accent)', marginBottom: 3 }}>
-        Coach
-      </div>
-      <div style={{ fontSize: 13, lineHeight: 1.35, color: 'var(--text-1)' }}>
-        {response}
-      </div>
-      {sources.length > 0 && (
-        <div style={{
-          marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 6,
-          color: 'var(--text-3)', fontSize: 10,
-        }}>
-          {sources.slice(0, 2).map((source) => (
-            <span key={source.key} style={{
-              border: '1px solid rgba(197,242,62,0.18)',
-              background: 'rgba(197,242,62,0.06)',
-              color: 'var(--accent)',
-              borderRadius: 999,
-              padding: '3px 7px',
-              whiteSpace: 'nowrap',
-            }}>
-              {source.authors} {source.year}
-            </span>
-          ))}
-        </div>
-      )}
-    </div>
-    <button
-      onClick={onClose}
-      aria-label="Dismiss coach response"
-      style={{
-        width: 28,
-        height: 28,
-        borderRadius: 14,
-        border: '1px solid var(--hairline)',
-        background: 'var(--overlay-1)',
-        color: 'var(--text-2)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        cursor: 'pointer',
-        flexShrink: 0,
-      }}
-    >
-      <Icon name="x" size={14} />
-    </button>
-  </div>
 );

--- a/ios/assistant.js
+++ b/ios/assistant.js
@@ -26,7 +26,7 @@
       throw new Error(payload.error || 'Coach assistant failed.');
     }
 
-    // Normalize on `response` so existing listeners (CoachOverlay, wake-word
+    // Normalize on `response` so existing listeners (CoachCapsule, wake-word
     // border reset) keep working unchanged.
     const reply = String(payload.reply || '').trim();
     const expectsFollowUp = looksLikeQuestion(reply);

--- a/ios/index.html
+++ b/ios/index.html
@@ -70,6 +70,7 @@
   <script type="text/babel" src="screens-past-workout.jsx"></script>
   <script type="text/babel" src="screens-calendar.jsx"></script>
   <script type="text/babel" src="screens-profile.jsx"></script>
+  <script type="text/babel" src="voice-agent.jsx"></script>
   <script type="text/babel" src="app.jsx"></script>
 </body>
 </html>

--- a/ios/screens-add-program.jsx
+++ b/ios/screens-add-program.jsx
@@ -514,10 +514,24 @@ const ProgramScheduleView = ({ source }) => {
   );
 };
 
+// Shared column geometry for the clean WORKOUT/SETS/REPS/WEIGHT table —
+// matches the live workout tracker so the program reads the same whether or
+// not it's active.
+const SCHEDULE_COLS = '1.6fr 36px 44px 56px 16px';
+const ScheduleTh = ({ children, right }) => (
+  <div className="mono" style={{
+    fontSize: 9, color: 'var(--text-3)', letterSpacing: 0.6,
+    textTransform: 'uppercase', textAlign: right ? 'right' : 'left',
+  }}>{children}</div>
+);
+
 const DaySection = ({ day, dayIndex }) => {
   const blocks = day.blocks || [];
   const exercises = blocks.flatMap((block) => block.exercises || []);
   const setCount = exercises.reduce((sum, exercise) => sum + normalizeSetCount(exercise.sets), 0);
+  // Most days are a single "Main" block — only surface block headers when a
+  // day actually splits into more than one, so the table stays clean.
+  const showBlockHeaders = blocks.length > 1;
 
   return (
     <section style={{
@@ -555,10 +569,23 @@ const DaySection = ({ day, dayIndex }) => {
         )}
       </div>
 
+      {/* Column header — WORKOUT / SETS / REPS / WEIGHT */}
+      <div style={{
+        display: 'grid', gridTemplateColumns: SCHEDULE_COLS, gap: 8, alignItems: 'center',
+        padding: '10px 14px', borderBottom: '1px solid var(--hairline)',
+      }}>
+        <ScheduleTh>Workout</ScheduleTh>
+        <ScheduleTh right>Sets</ScheduleTh>
+        <ScheduleTh right>Reps</ScheduleTh>
+        <ScheduleTh right>Weight</ScheduleTh>
+        <div />
+      </div>
+
       {blocks.map((block, blockIndex) => (
         <BlockSection
           key={block.id || blockIndex}
           block={block}
+          showHeader={showBlockHeaders}
           isLast={blockIndex === blocks.length - 1}
         />
       ))}
@@ -566,36 +593,38 @@ const DaySection = ({ day, dayIndex }) => {
   );
 };
 
-const BlockSection = ({ block, isLast }) => (
+const BlockSection = ({ block, showHeader, isLast }) => (
   <div style={{
     borderBottom: isLast ? 'none' : '1px solid var(--hairline)',
   }}>
-    <div style={{
-      padding: '11px 14px',
-      display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
-      background: 'rgba(197,242,62,0.045)',
-      borderBottom: '1px solid var(--hairline)',
-    }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-        <Icon name="columns" size={13} stroke="var(--accent)" />
-        <span style={{
-          color: 'var(--text-1)', fontSize: 12.5, fontWeight: 700,
-          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-        }}>
-          {block.title || 'Main'}
-        </span>
+    {showHeader && (
+      <div style={{
+        padding: '10px 14px',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
+        background: 'rgba(197,242,62,0.045)',
+        borderBottom: '1px solid var(--hairline)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+          <Icon name="columns" size={13} stroke="var(--accent)" />
+          <span style={{
+            color: 'var(--text-1)', fontSize: 12, fontWeight: 700,
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>
+            {block.title || 'Main'}
+          </span>
+        </div>
+        {block.executionStyle && (
+          <span className="mono" style={{
+            fontSize: 9, color: 'var(--accent)', whiteSpace: 'nowrap',
+            padding: '3px 7px', borderRadius: 999,
+            border: '1px solid rgba(197,242,62,0.24)',
+            background: 'rgba(197,242,62,0.08)',
+          }}>
+            {String(block.executionStyle).replace('_', ' ')}
+          </span>
+        )}
       </div>
-      {block.executionStyle && (
-        <span className="mono" style={{
-          fontSize: 9.5, color: 'var(--accent)', whiteSpace: 'nowrap',
-          padding: '3px 7px', borderRadius: 999,
-          border: '1px solid rgba(197,242,62,0.24)',
-          background: 'rgba(197,242,62,0.08)',
-        }}>
-          {String(block.executionStyle).replace('_', ' ')}
-        </span>
-      )}
-    </div>
+    )}
 
     {(block.exercises || []).map((exercise, index) => (
       <MobileExerciseRow
@@ -610,57 +639,42 @@ const BlockSection = ({ block, isLast }) => (
 const MobileExerciseRow = ({ exercise, isLast }) => {
   const [open, setOpen] = React.useState(false);
   const hasNote = !!exercise.note;
+  const hasLoad = exercise.load && exercise.load !== '-';
 
   return (
     <div style={{
       borderBottom: isLast ? 'none' : '1px solid var(--hairline)',
       background: 'var(--surface-1)',
     }}>
-      <button
+      <div
         onClick={() => hasNote && setOpen(!open)}
         className={hasNote ? 'press' : ''}
         style={{
-          width: '100%',
+          display: 'grid', gridTemplateColumns: SCHEDULE_COLS, gap: 8, alignItems: 'center',
           padding: '13px 14px',
-          background: 'transparent',
-          border: 'none',
-          color: 'var(--text-1)',
-          textAlign: 'left',
-          fontFamily: 'var(--font-sans)',
           cursor: hasNote ? 'pointer' : 'default',
         }}
       >
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{
-              fontSize: 14.5, fontWeight: 600, lineHeight: 1.25,
-              overflowWrap: 'anywhere',
-            }}>
-              {exercise.name}
-            </div>
-            <div style={{
-              display: 'flex', gap: 6, flexWrap: 'wrap',
-              marginTop: 9,
-            }}>
-              <MetricChip label="sets" value={exercise.sets} accent />
-              <MetricChip label="reps" value={exercise.reps} />
-              <MetricChip label="load" value={exercise.load} accent={exercise.load && exercise.load !== '-'} />
-              {exercise.rest && exercise.rest !== '-' && <MetricChip label="rest" value={exercise.rest} />}
-            </div>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 13, fontWeight: 500, letterSpacing: -0.1, lineHeight: 1.3, overflowWrap: 'anywhere' }}>
+            {exercise.name}
           </div>
-          {hasNote && (
-            <Icon
-              name="chevron-down"
-              size={14}
-              stroke="var(--text-3)"
-              style={{ marginTop: 2, transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 180ms ease' }}
-            />
+        </div>
+        <div className="mono" style={{ fontSize: 12, color: 'var(--text-2)', textAlign: 'right' }}>{exercise.sets || '-'}</div>
+        <div className="mono" style={{ fontSize: 12, color: 'var(--text-2)', textAlign: 'right' }}>{exercise.reps || '-'}</div>
+        <div className="mono" style={{ fontSize: 12, color: hasLoad ? 'var(--accent)' : 'var(--text-3)', textAlign: 'right', fontWeight: 600 }}>{exercise.load || '-'}</div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          {hasNote ? (
+            <Icon name="chevron-down" size={13} stroke="var(--text-3)"
+              style={{ transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 180ms ease' }} />
+          ) : (
+            <span style={{ width: 13, height: 13, display: 'block' }} />
           )}
         </div>
-      </button>
+      </div>
 
       {hasNote && (
-        <div style={{ maxHeight: open ? 180 : 0, overflow: 'hidden', transition: 'max-height 220ms ease' }}>
+        <div style={{ maxHeight: open ? 240 : 0, overflow: 'hidden', transition: 'max-height 220ms ease' }}>
           <div style={{
             padding: '0 14px 14px',
             color: 'var(--text-2)',
@@ -680,37 +694,6 @@ const MobileExerciseRow = ({ exercise, isLast }) => {
     </div>
   );
 };
-
-const MetricChip = ({ label, value, accent }) => (
-  <span style={{
-    minWidth: 0,
-    maxWidth: '100%',
-    display: 'inline-flex',
-    alignItems: 'baseline',
-    gap: 4,
-    padding: '5px 7px',
-    borderRadius: 9,
-    background: accent ? 'rgba(197,242,62,0.10)' : 'var(--surface-2)',
-    border: '1px solid ' + (accent ? 'rgba(197,242,62,0.22)' : 'var(--hairline)'),
-  }}>
-    <span className="mono" style={{
-      color: accent ? 'var(--accent)' : 'var(--text-1)',
-      fontSize: 12,
-      fontWeight: 700,
-      overflowWrap: 'anywhere',
-    }}>
-      {value || '-'}
-    </span>
-    <span className="mono" style={{
-      color: 'var(--text-3)',
-      fontSize: 8.5,
-      textTransform: 'uppercase',
-      letterSpacing: 0.35,
-    }}>
-      {label}
-    </span>
-  </span>
-);
 
 function getProgramDays(source) {
   if (Array.isArray(source.days)) return source.days;

--- a/ios/screens-main.jsx
+++ b/ios/screens-main.jsx
@@ -128,7 +128,7 @@ const HomeScreen = ({
 
             <Button
               onClick={(e) => { e.stopPropagation(); onFinish && onFinish(); }}
-              icon="check"
+              icon="trophy"
               variant="surface"
               style={{
                 background: 'var(--surface-2)', color: 'var(--text-1)',
@@ -216,6 +216,128 @@ const HomeScreen = ({
   );
 };
 
+// ─────────────────────────────────────────────────────────────
+// LIVE WORKOUT TRACKER — while a workout is active, makes it clear
+// which exercise + which set you're on. The clean WORKOUT/SETS/REPS/
+// WEIGHT table matches the inactive program view; the active lift gets
+// a hero row + per-set breakdown, finished work reads as done, and the
+// coach's weight edits can flash on the real plan (overrides/flashKey).
+// ─────────────────────────────────────────────────────────────
+const LiveWorkoutList = ({ exercises, pos, overrides = {}, flashKey = null }) => {
+  const COLS = '1.6fr 36px 44px 56px 16px';
+  const Th = ({ children, right }) => (
+    <div className="mono" style={{ fontSize: 9, color: 'var(--text-3)', letterSpacing: 0.6, textTransform: 'uppercase', textAlign: right ? 'right' : 'left' }}>{children}</div>
+  );
+  return (
+    <Card padding={0}>
+      {/* Column header — identical to the inactive inspect view. */}
+      <div style={{ display: 'grid', gridTemplateColumns: COLS, gap: 8, alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--hairline)' }}>
+        <Th>Workout</Th><Th right>Sets</Th><Th right>Reps</Th><Th right>Weight</Th><div />
+      </div>
+
+      {exercises.map((ex, i) => {
+        const isActive = i === pos.ex;
+        const isDone = i < pos.ex;
+        const last = i === exercises.length - 1;
+        const rowBorder = last ? 'none' : '1px solid var(--hairline)';
+
+        // ── ACTIVE — summary row + per-set tracker, kept inside the table ──
+        if (isActive) {
+          const liveLoad = overrides[i + '-' + pos.set] || ex.load;
+          return (
+            <div key={i} className="fade-up" style={{
+              borderBottom: rowBorder,
+              background: 'var(--hero-bg)',
+              boxShadow: 'inset 2px 0 0 var(--accent)',
+            }}>
+              {/* Summary row */}
+              <div style={{ display: 'grid', gridTemplateColumns: COLS, gap: 8, alignItems: 'center', padding: '12px 14px' }}>
+                <div style={{ minWidth: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span className="pulse-dot" style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--accent)', flexShrink: 0 }} />
+                  <div style={{ minWidth: 0 }}>
+                    <div className="mono" style={{ fontSize: 8.5, letterSpacing: 0.7, color: 'var(--accent)', lineHeight: 1 }}>NOW LIFTING</div>
+                    <div style={{ fontSize: 13, fontWeight: 600, letterSpacing: -0.1, lineHeight: 1.3, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ex.name}</div>
+                  </div>
+                </div>
+                <div className="mono" style={{ fontSize: 12, textAlign: 'right', fontWeight: 700, color: 'var(--text-1)' }}>{pos.set + 1}<span style={{ color: 'var(--text-3)', fontWeight: 400 }}>/{ex.sets}</span></div>
+                <div className="mono" style={{ fontSize: 12, color: 'var(--text-2)', textAlign: 'right' }}>{ex.reps}</div>
+                <div className="mono" style={{ fontSize: 12, color: 'var(--accent)', textAlign: 'right', fontWeight: 600 }}>{liveLoad}</div>
+                <div />
+              </div>
+
+              {/* Per-set rows — aligned to the same columns */}
+              {Array.from({ length: ex.sets }).map((_, sIdx) => {
+                const sDone = sIdx < pos.set;
+                const sCurrent = sIdx === pos.set;
+                const key = i + '-' + sIdx;
+                const load = overrides[key] || ex.load;
+                const flashing = flashKey === key;
+                return (
+                  <div key={sIdx} style={{
+                    display: 'grid', gridTemplateColumns: COLS, gap: 8, alignItems: 'center',
+                    padding: '9px 14px',
+                    borderTop: '1px solid var(--hairline)',
+                    background: sCurrent ? 'var(--accent-soft)' : 'transparent',
+                    opacity: sDone ? 0.5 : 1,
+                    transition: 'background 200ms, opacity 200ms',
+                  }}>
+                    <div style={{ minWidth: 0, display: 'flex', alignItems: 'center', gap: 8, paddingLeft: 14 }}>
+                      <span style={{
+                        width: 16, height: 16, borderRadius: 5, flexShrink: 0,
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        background: sDone ? 'transparent' : sCurrent ? 'var(--accent)' : 'var(--surface-3)',
+                      }}>
+                        {sDone
+                          ? <Icon name="check" size={11} stroke="var(--accent)" strokeWidth={2.5} />
+                          : <span className="mono" style={{ fontSize: 9.5, fontWeight: 700, color: sCurrent ? 'var(--on-accent)' : 'var(--text-2)' }}>{sIdx + 1}</span>}
+                      </span>
+                      <span className="mono" style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-1)' }}>{'Set ' + (sIdx + 1)}</span>
+                      {sCurrent && (
+                        <span className="mono" style={{ fontSize: 8, fontWeight: 700, letterSpacing: 0.6, color: 'var(--accent)' }}>TRACKING</span>
+                      )}
+                    </div>
+                    <div />
+                    <div className={'mono' + (flashing ? ' cell-flash' : '')} style={{ fontSize: 12, textAlign: 'right', color: 'var(--text-2)' }}>{ex.reps}</div>
+                    <div className={'mono' + (flashing ? ' cell-flash' : '')} style={{ fontSize: 12, textAlign: 'right', fontWeight: 600, color: 'var(--accent)' }}>{load}</div>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                      {sDone && <Icon name="check" size={12} stroke="var(--text-3)" strokeWidth={2.5} />}
+                    </div>
+                  </div>
+                );
+              })}
+
+              {ex.note && (
+                <div style={{ padding: '10px 14px 12px 28px', borderTop: '1px solid var(--hairline)' }}>
+                  <div className="mono" style={{ fontSize: 9, color: 'var(--text-3)', letterSpacing: 0.5, textTransform: 'uppercase', marginBottom: 4 }}>Notes</div>
+                  <div style={{ fontSize: 12, color: 'var(--text-2)', lineHeight: 1.45 }}>{ex.note}</div>
+                </div>
+              )}
+            </div>
+          );
+        }
+
+        // ── DONE / UPCOMING — single clean row, same as inspect ──
+        return (
+          <div key={i} style={{
+            display: 'grid', gridTemplateColumns: COLS, gap: 8, alignItems: 'center',
+            padding: '13px 14px', borderBottom: rowBorder,
+            opacity: isDone ? 0.45 : 1,
+          }}>
+            <div style={{ minWidth: 0, display: 'flex', alignItems: 'center', gap: 7 }}>
+              {isDone && <Icon name="check" size={13} stroke="var(--accent)" strokeWidth={2.5} style={{ flexShrink: 0 }} />}
+              <div style={{ fontSize: 13, fontWeight: 500, letterSpacing: -0.1, lineHeight: 1.25, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: isDone ? 'var(--text-2)' : 'var(--text-1)' }}>{ex.name}</div>
+            </div>
+            <div className="mono" style={{ fontSize: 12, color: 'var(--text-2)', textAlign: 'right' }}>{ex.sets}</div>
+            <div className="mono" style={{ fontSize: 12, color: 'var(--text-2)', textAlign: 'right' }}>{ex.reps}</div>
+            <div className="mono" style={{ fontSize: 12, color: isDone ? 'var(--text-3)' : 'var(--accent)', textAlign: 'right', fontWeight: 600 }}>{ex.load}</div>
+            <div />
+          </div>
+        );
+      })}
+    </Card>
+  );
+};
+
 const RunningWorkoutScreen = ({
   programId,
   sessionId,
@@ -236,20 +358,30 @@ const RunningWorkoutScreen = ({
   const selectedDay = day?.id
     ? (detail.days || []).find((item) => item.id === day.id) || day
     : (day || (detail.days || [])[0] || null);
-  const exercises = selectedDay?.blocks?.length
+  const rawExercises = selectedDay?.blocks?.length
     ? selectedDay.blocks.flatMap((block) => block.exercises || [])
     : (detail.exercises || []);
-  const currentName = step?.exerciseName || exercises[0]?.name || 'Workout';
+  // The live tracker draws one row per set, so coerce whatever the backend
+  // stored for the count ("5", "5×3", "-") into a concrete number.
+  const exercises = rawExercises.map((exercise) => ({
+    ...exercise,
+    sets: Number.parseInt(exercise.sets, 10) || 1,
+  }));
+  const currentName = step?.exerciseName || exercises[0]?.name || '';
   const currentIndex = Math.max(0, exercises.findIndex((exercise) => normalizeRunningName(exercise.name) === normalizeRunningName(currentName)));
-  const setNumber = step?.setNumber || 1;
-  const setCount = step?.setCount || Number.parseInt(exercises[currentIndex]?.sets, 10) || 1;
+  const setNumber = Number.parseInt(step?.setNumber, 10) || 1;
+  // step goes null once the final set is logged → the whole workout is done.
+  const allDone = !step || currentIndex >= exercises.length;
+  const pos = allDone
+    ? { ex: exercises.length, set: 0 }
+    : { ex: currentIndex, set: Math.max(0, setNumber - 1) };
 
   return (
-    <Screen padTop={58} padBottom={24} style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <Screen padTop={58} padBottom={132}>
+      {/* Header — collapse + HUD demo + live status */}
       <div style={{
         padding: '0 20px 16px',
         display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        flexShrink: 0,
       }}>
         <button onClick={onClose} className="press" style={{
           width: 38, height: 38, borderRadius: 9999,
@@ -258,115 +390,76 @@ const RunningWorkoutScreen = ({
         }}>
           <Icon name="chevron-down" size={18} />
         </button>
-        <Pill accent>Live workout</Pill>
-      </div>
-
-      <div style={{ padding: '0 20px 18px', flexShrink: 0 }}>
-        <div style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 6 }}>
-          {program.name || 'Workout'}{selectedDay?.title ? ` - ${selectedDay.title}` : ''}
-        </div>
-        <h1 style={{ fontSize: 34, lineHeight: 1.02, fontWeight: 650, letterSpacing: -0.7, margin: 0 }}>
-          {currentName}
-        </h1>
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 14 }}>
-          <Pill>Set {setNumber} of {setCount}</Pill>
-          {step?.repTarget && <Pill>{step.repTarget} reps</Pill>}
-          {step?.loadTarget && <Pill>{step.loadTarget}</Pill>}
-          {(rest?.durationSeconds || step?.restSeconds) && (
-            <Pill>{rest ? 'Rest active' : `${step.restSeconds}s rest`}</Pill>
-          )}
-        </div>
-      </div>
-
-      <div style={{
-        padding: '0 20px 16px',
-        display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10,
-        flexShrink: 0,
-      }}>
-        <Button size="md" icon="arrow-right" onClick={onNextSet}>Next set</Button>
-        <Button size="md" variant="surface" icon="chevron-right" onClick={onSkipExercise}>Skip exercise</Button>
-      </div>
-
-      {lastLoggedSet && (
-        <div style={{ padding: '0 20px 16px', flexShrink: 0 }}>
-          <div style={{
-            padding: '12px 14px',
-            borderRadius: 'var(--r-card)',
-            background: 'var(--surface-1)',
-            border: '1px solid rgba(197,242,62,0.32)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button onClick={onOpenHud} className="press" aria-label="HUD demo" title="HUD demo" style={{
+            width: 38, height: 38, borderRadius: 9999,
+            background: 'var(--surface-1)', border: '1px solid var(--hairline)',
+            color: 'var(--text-2)', display: 'flex', alignItems: 'center', justifyContent: 'center',
           }}>
-            <div style={{
-              width: 28, height: 28, borderRadius: 9999,
-              background: 'var(--accent)',
-              color: 'var(--on-accent)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-              flexShrink: 0,
-            }}>
-              <Icon name="check" size={14} stroke="var(--on-accent)" />
-            </div>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 2 }}>Last logged set</div>
-              <div style={{ fontSize: 14, fontWeight: 650, color: 'var(--text-1)' }}>
-                {lastLoggedSet.exerciseName || currentName}: {lastLoggedSet.reps ?? '-'} reps
-                {lastLoggedSet.weight != null ? ` at ${lastLoggedSet.weight} lb` : ''}
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      <div style={{ padding: '0 20px 16px', flexShrink: 0 }}>
-        <Button size="md" variant="dark" icon="video" onClick={onOpenHud}>
-          HUD demo
-        </Button>
-      </div>
-
-      <div style={{ flex: 1, overflowY: 'auto', padding: '0 20px 18px' }}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {exercises.map((exercise, index) => {
-            const active = index === currentIndex;
-            const done = currentIndex > -1 && index < currentIndex;
-            return (
-              <div key={`${exercise.id || exercise.name}-${index}`} style={{
-                minHeight: 64,
-                padding: '12px 14px',
-                borderRadius: 'var(--r-card)',
-                background: active ? 'var(--accent-soft)' : 'var(--surface-1)',
-                border: active ? '1px solid rgba(197,242,62,0.45)' : '1px solid var(--hairline)',
-                color: active ? 'var(--text-1)' : 'var(--text-2)',
-                display: 'flex', alignItems: 'center', gap: 12,
-                opacity: done ? 0.62 : 1,
-              }}>
-                <div style={{
-                  width: 30, height: 30, borderRadius: 9999,
-                  background: active ? 'var(--accent)' : 'var(--surface-2)',
-                  color: active ? 'var(--on-accent)' : 'var(--text-3)',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  fontSize: 12, fontWeight: 700, flexShrink: 0,
-                }}>
-                  {done ? <Icon name="check" size={14} stroke={active ? 'var(--on-accent)' : 'var(--text-3)'} /> : index + 1}
-                </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 15, fontWeight: active ? 700 : 600, color: active ? 'var(--text-1)' : 'var(--text-2)' }}>
-                    {exercise.name}
-                  </div>
-                  <div style={{ fontSize: 12, color: active ? 'var(--accent)' : 'var(--text-3)', marginTop: 3 }}>
-                    {exercise.sets || '-'} sets · {exercise.reps || '-'} reps · {exercise.load || '-'}
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+            <Icon name="video" size={16} />
+          </button>
+          <Pill accent>
+            <span style={{
+              display: 'inline-block', width: 6, height: 6, borderRadius: '50%',
+              background: 'var(--accent)', marginRight: 6, boxShadow: '0 0 6px var(--accent)',
+            }} />
+            Live workout
+          </Pill>
         </div>
       </div>
 
-      <div style={{ padding: '0 20px', flexShrink: 0 }}>
-        <Button variant="surface" icon="check" onClick={() => onFinish && onFinish(sessionId, programId)}>
-          Finish workout
-        </Button>
+      {/* Title — the program; the active lift is distinguished in the table. */}
+      <div style={{ padding: '0 20px 18px' }}>
+        <h1 style={{ fontSize: 30, lineHeight: 1.1, fontWeight: 600, letterSpacing: -0.6, margin: 0, marginBottom: 8 }}>
+          {program.name || 'Workout'}
+        </h1>
+        <p style={{ fontSize: 13, color: 'var(--text-2)', margin: 0, lineHeight: 1.5 }}>
+          {allDone
+            ? 'Every set logged — finish when you are ready.'
+            : 'Working through your sets — your glasses track each rep automatically.'}
+          {selectedDay?.title ? ` · ${selectedDay.title}` : ''}
+        </p>
+      </div>
+
+      {/* Clean table — matches the inactive program; the current lift + set
+          are highlighted, finished work reads as done. */}
+      <div style={{ padding: '0 20px' }}>
+        <LiveWorkoutList exercises={exercises} pos={pos} />
+      </div>
+
+      {/* Bottom controls — two round FABs, single height, bottom-right.
+          Log set (check) advances the tracker; the trophy stays grey
+          (tappable to finish early) until every set is logged, then turns
+          accent-green — at which point only it remains. */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0,
+        padding: '16px 20px 24px',
+        background: 'linear-gradient(180deg, transparent, var(--bg) 30%)',
+        display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 12,
+        pointerEvents: 'none',
+      }}>
+        {!allDone && (
+          <button onClick={onNextSet} className="press" aria-label="Log set" title="Log set" style={{
+            pointerEvents: 'auto',
+            width: 58, height: 58, borderRadius: 9999,
+            background: 'var(--accent)', border: 'none', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            boxShadow: '0 6px 16px rgba(0,0,0,0.35)',
+          }}>
+            <Icon name="check" size={24} stroke="var(--on-accent)" strokeWidth={2.4} />
+          </button>
+        )}
+        <button onClick={() => onFinish && onFinish(sessionId, programId)} className="press" aria-label={allDone ? 'Finish workout' : 'Finish early'} title={allDone ? 'Finish workout' : 'Finish early'} style={{
+          pointerEvents: 'auto',
+          width: 58, height: 58, borderRadius: 9999, cursor: 'pointer',
+          background: allDone ? 'var(--accent)' : 'var(--surface-2)',
+          border: allDone ? 'none' : '1px solid var(--hairline-2)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          boxShadow: allDone ? '0 6px 18px rgba(0,0,0,0.35), var(--accent-glow)' : '0 4px 12px rgba(0,0,0,0.30)',
+          transition: 'background 260ms ease, box-shadow 260ms ease, border-color 260ms ease',
+        }}>
+          <Icon name="trophy" size={24} stroke={allDone ? 'var(--on-accent)' : 'var(--text-3)'} strokeWidth={2} />
+        </button>
       </div>
     </Screen>
   );

--- a/ios/screens-program-detail.jsx
+++ b/ios/screens-program-detail.jsx
@@ -214,7 +214,7 @@ const ProgramViewScreen = ({
         {loadedToGlasses ? (
           <Button
             onClick={onFinishWorkout}
-            icon="check"
+            icon="trophy"
             variant="surface"
             style={{ background: 'var(--surface-2)', color: 'var(--text-1)', border: '1px solid var(--accent)' }}
           >

--- a/ios/screens-signup.jsx
+++ b/ios/screens-signup.jsx
@@ -31,19 +31,14 @@ const SplashScreen = ({ onSignUp, onSignIn }) => (
       background: 'radial-gradient(120% 80% at 50% 30%, rgba(197,242,62,0.18), transparent 60%)',
       paddingTop: 80,
     }}>
-      {/* Glasses visor — pure CSS */}
-      <div style={{ width: 220, height: 110, position: 'relative', marginBottom: 56 }}>
-        <div style={{
-          position: 'absolute', inset: 0, borderRadius: '50%',
-          border: '1.5px solid var(--accent)',
-          boxShadow: '0 0 60px rgba(197,242,62,0.4), inset 0 0 30px rgba(197,242,62,0.15)',
-          background: 'linear-gradient(180deg, rgba(197,242,62,0.08), transparent 60%)',
-        }} />
-        <div style={{
-          position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)',
-          fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: 3,
-          color: 'rgba(197,242,62,0.7)',
-        }}>TRAIN.AR</div>
+      {/* Landing symbol — glasses mark */}
+      <div style={{
+        marginBottom: 56,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: 'var(--accent)',
+        filter: 'drop-shadow(0 0 26px rgba(197,242,62,0.45))',
+      }}>
+        <Icon name="glasses" size={140} stroke="var(--accent)" strokeWidth={1.2} />
       </div>
 
       <div style={{ textAlign: 'center', padding: '0 32px' }}>
@@ -58,7 +53,7 @@ const SplashScreen = ({ onSignUp, onSignIn }) => (
           fontSize: 15, lineHeight: 1.5, color: 'var(--text-2)', margin: 0,
           maxWidth: 300, marginInline: 'auto',
         }}>
-          Your program lives in your AR glasses. The phone is just for setup.
+          Your program lives in your AR glasses.
         </p>
       </div>
     </div>
@@ -106,14 +101,9 @@ const AuthScreen = ({ auth, initialMode = 'signup', onContinue, onBack }) => {
           marginBottom: 32,
         }}><Icon name="arrow-left" size={18} /></button>
 
-        <h1 style={{ fontSize: 30, lineHeight: 1.1, fontWeight: 600, letterSpacing: -0.8, margin: 0, marginBottom: 12 }}>
+        <h1 style={{ fontSize: 30, lineHeight: 1.1, fontWeight: 600, letterSpacing: -0.8, margin: 0, marginBottom: 28 }}>
           {mode === 'signup' ? 'Create your account' : 'Welcome back'}
         </h1>
-        <p style={{ fontSize: 14, lineHeight: 1.5, color: 'var(--text-2)', margin: 0, marginBottom: 28 }}>
-          {mode === 'signup'
-            ? "We'll sync this account to your glasses so your programs follow you everywhere."
-            : 'Sign in to pick up where you left off.'}
-        </p>
 
         <Field
           label="Email"
@@ -218,11 +208,8 @@ const NameScreen = ({ auth, onContinue, onBack }) => {
         <div className="fade-up">
           <h1 style={{
             fontSize: 30, lineHeight: 1.15, fontWeight: 600, letterSpacing: -0.7,
-            margin: 0, marginBottom: 10,
+            margin: 0, marginBottom: 32,
           }}>What should we call you?</h1>
-          <p style={{ fontSize: 14, color: 'var(--text-2)', margin: 0, marginBottom: 32 }}>
-            Just a first name is fine — we'll use it on the glasses too.
-          </p>
 
           <label style={{
             display: 'block', fontSize: 11, color: 'var(--text-3)', marginBottom: 8,
@@ -240,21 +227,6 @@ const NameScreen = ({ auth, onContinue, onBack }) => {
               outline: 'none',
             }}
           />
-
-          <Card padding={16} style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 12 }}>
-            <div style={{
-              width: 36, height: 36, borderRadius: 10, background: 'var(--accent-soft)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-            }}>
-              <Icon name="bolt" size={18} stroke="var(--accent)" />
-            </div>
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 13, fontWeight: 600 }}>Quick setup</div>
-              <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 2 }}>
-                Next, we will tune your training profile.
-              </div>
-            </div>
-          </Card>
         </div>
       </div>
 

--- a/ios/tokens.css
+++ b/ios/tokens.css
@@ -112,6 +112,41 @@
   box-shadow: 0 0 0 1px rgba(197, 242, 62, 0.6), 0 0 24px rgba(197, 242, 62, 0.35);
 }
 
+/* ── Voice coach + live set tracker ── */
+
+/* Waveform bars — the coach's identity motif while listening/thinking. */
+@keyframes voiceBar {
+  0%, 100% { transform: scaleY(0.30); }
+  50%      { transform: scaleY(1); }
+}
+.va-bar { transform-origin: center center; animation: voiceBar 0.9s ease-in-out infinite; }
+
+/* Expanding rings behind the capsule indicator while listening. */
+@keyframes orbRing {
+  0%   { transform: scale(0.72); opacity: 0.55; }
+  100% { transform: scale(1.7);  opacity: 0; }
+}
+.orb-ring { animation: orbRing 2.4s ease-out infinite; }
+
+/* Slim capsule slides up from the bottom when the coach activates. */
+@keyframes capsuleIn {
+  from { transform: translateY(16px) scale(0.96); opacity: 0; }
+  to   { transform: translateY(0) scale(1); opacity: 1; }
+}
+.capsule-in { animation: capsuleIn 320ms cubic-bezier(.2,.8,.2,1) both; }
+
+/* A set cell flashes lime when the coach edits its weight on the live plan. */
+@keyframes cellFlash {
+  0%   { background: rgba(197,242,62,0);    box-shadow: 0 0 0 0 rgba(197,242,62,0); }
+  25%  { background: var(--accent);          box-shadow: 0 0 0 3px rgba(197,242,62,0.25); }
+  100% { background: rgba(197,242,62,0.16);  box-shadow: 0 0 0 0 rgba(197,242,62,0); }
+}
+.cell-flash { animation: cellFlash 1.2s cubic-bezier(.2,.8,.2,1) both; color: var(--on-accent) !important; }
+
+/* Blinking caret on the live transcript. */
+@keyframes caretBlink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+.caret-blink { animation: caretBlink 1s step-end infinite; }
+
 /* OCR scan sweep — runs across the parsing preview thumb. */
 @keyframes scanSweep {
   0%   { top: 0%;   opacity: 0; }

--- a/ios/voice-agent.jsx
+++ b/ios/voice-agent.jsx
@@ -1,0 +1,160 @@
+// TrainAR — Voice coach surface.
+//
+// The coach is activated by VOICE through the AR glasses (wake word), so there
+// is deliberately NO mic button or "Hey Coach" tap target on the phone. The
+// phone shows nothing until the real wake-word / voice-command events fire from
+// the native bridge; then a slim capsule slides up at the bottom. It never dims
+// or covers the plan, so when the coach logs a set or edits a weight, that
+// change stays visible on the training table right above it.
+//
+// This file only provides the visuals (Waveform, CapIndicator, CoachCapsule).
+// The state that drives them is owned by app.jsx and comes straight from the
+// backend coach events (trainar:glasses wakeWordDetected/voiceCommand and
+// trainar:coach-response / trainar:coach-action).
+
+// ─────────────────────────────────────────────────────────────
+// Waveform — the coach's identity motif: lime bars that breathe.
+// ─────────────────────────────────────────────────────────────
+const Waveform = ({ phase = 'listening', barW = 2.5, gap = 2.5, height = 15, count = 5, color = 'var(--accent)' }) => {
+  const cfg = {
+    listening: { dur: 0.7, peaks: [0.5, 0.95, 0.45, 1, 0.6] },
+    thinking:  { dur: 1.25, peaks: [0.32, 0.42, 0.3, 0.44, 0.32] },
+    idle:      { dur: 0, peaks: [0.35, 0.6, 0.4, 0.62, 0.4] },
+  }[phase] || { dur: 0, peaks: [0.4, 0.5, 0.4, 0.5, 0.4] };
+  const animated = cfg.dur > 0;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap, height }}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className={animated ? 'va-bar' : ''} style={{
+          width: barW, height, borderRadius: barW, background: color,
+          transform: animated ? undefined : `scaleY(${cfg.peaks[i % cfg.peaks.length]})`,
+          animationDuration: animated ? `${cfg.dur}s` : undefined,
+          animationDelay: animated ? `${(i * cfg.dur) / count - cfg.dur}s` : undefined,
+          opacity: phase === 'thinking' ? 0.7 : 1,
+        }} />
+      ))}
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────
+// CapIndicator — round indicator that fronts the capsule:
+// listening waveform → thinking spinner → result check / waveform.
+// ─────────────────────────────────────────────────────────────
+const CapIndicator = ({ state, result }) => {
+  const ring = state === 'listening';
+  const bg = (state === 'result' && result)
+    ? (result.kind === 'action' ? 'var(--accent)' : 'var(--accent-soft)')
+    : 'var(--surface-3)';
+  return (
+    <div style={{ position: 'relative', width: 36, height: 36, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {ring && [0, 1].map((i) => (
+        <span key={i} className="orb-ring" style={{ position: 'absolute', inset: 0, borderRadius: '50%', border: '1.5px solid var(--accent)', animationDelay: `${i * 1.1}s` }} />
+      ))}
+      <div style={{
+        width: 36, height: 36, borderRadius: '50%', background: bg,
+        border: '1px solid ' + (state === 'result' && result && result.kind === 'info' ? 'rgba(197,242,62,0.4)' : (ring ? 'var(--accent)' : 'var(--hairline-2)')),
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        boxShadow: ring ? '0 0 18px rgba(197,242,62,0.4)' : 'none',
+        transition: 'background 240ms',
+      }}>
+        {state === 'thinking'
+          ? <div className="spin-ring" style={{ width: 15, height: 15, borderRadius: '50%', border: '2px solid var(--overlay-3)', borderTopColor: 'var(--accent)' }} />
+          : state === 'result' && result
+            ? (result.kind === 'action'
+                ? <Icon name="check" size={18} stroke="var(--on-accent)" strokeWidth={2.5} />
+                : <Waveform phase="idle" height={13} barW={2.5} gap={2.5} count={4} />)
+            : <Waveform phase={state === 'listening' ? 'listening' : 'idle'} height={15} barW={2.5} gap={2.5} count={5} />}
+      </div>
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────
+// CoachCapsule — the only on-screen coach surface. Appears once the
+// wake word fires; slides up as a slim bottom capsule that leaves the
+// plan visible above it. States: listening → thinking → result.
+//   state      'listening' | 'thinking' | 'result'
+//   transcript what was heard (shown while listening/thinking)
+//   result     { text, kind: 'action' | 'info' } when answered
+// ─────────────────────────────────────────────────────────────
+const CoachCapsule = ({ state, transcript = '', result = null, sources = [], onClose, bottomBase = 86 }) => {
+  const isResult = state === 'result' && !!result;
+  const statusLabel = state === 'listening'
+    ? 'LISTENING'
+    : state === 'thinking'
+      ? 'THINKING'
+      : isResult
+        ? (result.kind === 'action' ? 'DONE' : 'COACH')
+        : 'COACH';
+  const accentEdge = isResult
+    ? (result.kind === 'action' ? 'var(--accent)' : 'rgba(197,242,62,0.4)')
+    : (state === 'listening' ? 'var(--accent)' : 'var(--hairline-2)');
+
+  return (
+    <div style={{ position: 'absolute', left: 12, right: 12, bottom: bottomBase, zIndex: 60 }}>
+      <div className="capsule-in" style={{
+        display: 'flex', alignItems: isResult ? 'flex-start' : 'center', gap: 12,
+        padding: '11px 14px', borderRadius: 20,
+        background: 'var(--surface-1)',
+        border: '1px solid ' + accentEdge,
+        boxShadow: '0 14px 36px rgba(0,0,0,0.5)',
+      }}>
+        <CapIndicator state={state} result={result} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="mono" style={{
+            fontSize: 8.5, letterSpacing: 0.9,
+            color: isResult ? 'var(--accent)' : 'var(--text-3)',
+            display: 'flex', alignItems: 'center', gap: 5, marginBottom: 3,
+          }}>
+            {(state === 'listening' || isResult) && (
+              <span className="pulse-dot" style={{ width: 4, height: 4, borderRadius: '50%', background: 'var(--accent)', display: 'inline-block' }} />
+            )}
+            {statusLabel}
+          </div>
+          {isResult ? (
+            <div>
+              <div style={{ fontSize: 13.5, lineHeight: 1.35, color: 'var(--text-1)', fontWeight: 500 }}>{result.text}</div>
+              {sources.length > 0 && (
+                <div style={{ marginTop: 7, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                  {sources.slice(0, 2).map((source, i) => (
+                    <span key={source.key || i} style={{
+                      border: '1px solid rgba(197,242,62,0.18)',
+                      background: 'rgba(197,242,62,0.06)',
+                      color: 'var(--accent)',
+                      borderRadius: 999, padding: '3px 7px', whiteSpace: 'nowrap',
+                      fontSize: 10,
+                    }}>
+                      {source.authors} {source.year}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div style={{
+              fontSize: 15, lineHeight: 1.3, fontWeight: 500, letterSpacing: -0.2,
+              color: transcript ? 'var(--text-1)' : 'var(--text-3)',
+              overflow: 'hidden', textOverflow: 'ellipsis',
+            }}>
+              {transcript || (state === 'thinking' ? 'Thinking…' : 'Listening…')}
+              {state === 'listening' && <span className="caret-blink" style={{ color: 'var(--accent)' }}>|</span>}
+            </div>
+          )}
+        </div>
+        {isResult && onClose && (
+          <button onClick={onClose} aria-label="Dismiss coach" className="press" style={{
+            width: 26, height: 26, borderRadius: 13, flexShrink: 0,
+            border: '1px solid var(--hairline)', background: 'var(--overlay-1)',
+            color: 'var(--text-2)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            cursor: 'pointer',
+          }}>
+            <Icon name="x" size={13} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+Object.assign(window, { Waveform, CapIndicator, CoachCapsule });


### PR DESCRIPTION
Integrates the Claude Design prototype look into the real `ios/` WebView app. The backend (Supabase + `/api/chat` coach wiring) is **unchanged** — where the prototype and backend diverged, the frontend demo was adjusted to fit the backend while keeping the look.

## Signup / login (`screens-signup.jsx`)
- New landing **glasses mark** in place of the old CSS "TRAIN.AR" oval.
- Removed "The phone is just for setup." and the informational subheaders under **Create your account / Welcome back / What should we call you?**, plus the leftover **Quick setup** card. (The glasses-pairing step was already gone.)

## Training program (`screens-main.jsx`, `screens-add-program.jsx`, `screens-program-detail.jsx`)
- The **inactive program** and the **live workout** now render as the same clean **WORKOUT / SETS / REPS / WEIGHT** table (new `LiveWorkoutList`), so the program reads consistently whether or not it's active. Block sub-headers only appear when a day has more than one block.
- Live tracker marks the current lift **NOW LIFTING** and the current set **TRACKING**, dims finished work, and replaces the old two-row button stack with **two round FABs**: log-set (check) + finish (**trophy**, grey/tappable to finish early → turns lime once every set is logged, at which point the check FAB disappears). All finish controls now use the trophy.

## Voice coach (`voice-agent.jsx` *(new)*, `app.jsx`, `tokens.css`)
- Replaced the boxy coach overlay with a **slim capsule** (waveform orb → spinner → result) driven entirely by the existing backend events (`wakeWordDetected` → listening, `voiceCommand` → thinking w/ heard transcript, `coach-response` / `coach-action` → result). Coach actions still land on the live plan above the capsule.
- **No on-screen mic / "Hey Coach" button** — that was only the prototype's click-to-simulate affordance. Activation is by voice through the glasses.

## Reviewer notes (intentional backend-fit compromises)
- Live tracker drops the old "Next set / Skip exercise" buttons, "Last logged set" card, and rest pill in favor of the table + FABs. Skip/rest remain voice-driven; the log-set FAB advances the tracker exactly as the old "Next set" did. HUD-demo moved to a small video icon in the header.
- `LiveWorkoutList` carries the design's weight-flash support, but the backend has no per-set weight-override action so it simply never flashes (graceful).
- Kept the existing full-screen lime "listening" border alongside the capsule (glanceable, doesn't cover the plan) — trivial to drop if we want to match the prototype exactly.

## Verification
Smoke-tested by rendering the real files through the app's in-browser Babel (static preview): splash, auth (signup + login), name, inactive program (single + multi-block), live tracker (mid-workout + all-done), and the coach capsule (listening + action) all render correctly with **zero console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)