### PR TITLE
Fix TypeError crashing the /api/chat evidence path

### DIFF
--- a/src/assistant/evidence.py
+++ b/src/assistant/evidence.py
@@ -253,7 +253,7 @@ def format_evidence_context(sources: list[EvidenceSource]) -> str:
     for source in sources:
         lines.append(
             "- "
-            f"{source.citation()}, {source.journal}: {source.summary} "
+            f"{source.citation}, {source.journal}: {source.summary} "
             f"Coach use: {source.coach_note} URL: {source.url}"
         )
     return "\n".join(lines)


### PR DESCRIPTION
## Problem
`format_evidence_context` in `src/assistant/evidence.py` called `source.citation()`, but `citation` is a `@property` returning a `str`. Invoking it raised `TypeError: 'str' object is not callable`, which **500'd `/api/chat`** for *any* question that retrieved an evidence source (e.g. "how many sets per week for muscle growth?"). Questions that matched no source happened to work, which masked it.

## Fix
One line: `source.citation()` → `source.citation`.

## Test
Verified locally — an evidence-matched question now returns a normal reply plus a populated `sources` array, no traceback:
> "Aim for about 10 to 20 hard sets per muscle group weekly … Schoenfeld et al. found this drives good hypertrophy."

🤖 Generated with [Claude Code](https://claude.com/claude-code)