### PR TITLE
Groq fallback + native spreadsheet ingestion + route cleanup

### DIFF
--- a/src/app/program_review/web_demo.py
+++ b/src/app/program_review/web_demo.py
@@ -13,7 +13,6 @@ from flask import Flask, jsonify, render_template, request, send_from_directory
 
 from src.assistant.chat_route import register_chat_route
 from src.export.csv.exporter import register_export_routes
-from src.assistant.service import AssistantUnavailableError, handle_message
 from src.contracts import TrainingProgram
 from src.ingestion import UnsupportedProgramSourceError, extract_program_file, normalize_extracted_program
 from src.ingestion.llm_normalizer import (
@@ -140,24 +139,6 @@ def create_app() -> Flask:
         result = query_program_history(exercise or None)
         status_code = 200 if result.get("ok") else 404
         return jsonify(result), status_code
-
-    @app.post("/api/assistant/chat")
-    def assistant_chat_api():
-        payload = request.get_json(silent=True) or {}
-        message = str(payload.get("message", "")).strip()
-        context = payload.get("context") if isinstance(payload.get("context"), dict) else None
-        if not message:
-            return jsonify({"error": "Message is required."}), 400
-
-        try:
-            return jsonify(handle_message(message, context=context))
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
-        except AssistantUnavailableError as exc:
-            return jsonify({"error": str(exc)}), 503
-        except Exception:
-            LOGGER.exception("Unexpected error while handling assistant message.")
-            return jsonify({"error": "Coach assistant failed. Try again."}), 500
 
     return app
 

--- a/src/assistant/chat_route.py
+++ b/src/assistant/chat_route.py
@@ -9,7 +9,6 @@ the LLM with app context and short-lived conversation memory.
 from __future__ import annotations
 
 import logging
-import os
 import re
 from typing import Any
 
@@ -19,7 +18,7 @@ from src.assistant.context_manager import CoachContextManager
 from src.assistant.coach_style import style_action_reply, style_prompt_from_context
 from src.assistant.evidence import format_evidence_context, response_sources_payload, retrieve_evidence
 from src.assistant.models import AssistantAction
-from src.assistant.service import DEFAULT_ASSISTANT_MODEL, build_openai_client, handle_action, parse_user_message
+from src.assistant.service import build_openai_client, get_chat_model, handle_action, parse_user_message
 from src.assistant.supabase_tools import SupabaseToolError, execute_supabase_action
 
 LOGGER = logging.getLogger(__name__)
@@ -35,7 +34,6 @@ TRAINER_SYSTEM_PROMPT = (
     "as 'Schoenfeld et al.' Do not imply medical certainty."
 )
 
-CHAT_MODEL_ENV = "OPENAI_CHAT_MODEL"
 CHAT_MAX_TOKENS = 200
 DEFAULT_CHAT_SESSION_ID = "default"
 
@@ -152,15 +150,14 @@ def register_chat_route(app: Flask) -> None:
                 jsonify(
                     {
                         "error": (
-                            "OpenAI client not configured. Set OPENAI_API_KEY in .env "
-                            "and install the openai package."
+                            "Coach not configured. Set OPENAI_API_KEY or GROQ_API_KEY in .env."
                         )
                     }
                 ),
                 503,
             )
 
-        model = os.getenv(CHAT_MODEL_ENV, DEFAULT_ASSISTANT_MODEL)
+        model = get_chat_model()
         profile = app_context.get("trainingProfile") if isinstance(app_context, dict) else None
         evidence_sources = retrieve_evidence(text, profile=profile if isinstance(profile, dict) else None)
         evidence_context = format_evidence_context(evidence_sources)

--- a/src/assistant/service.py
+++ b/src/assistant/service.py
@@ -35,13 +35,32 @@ class AssistantUnavailableError(RuntimeError):
     """Raised when the configured LLM assistant cannot return an action."""
 
 
-def build_openai_client() -> "OpenAIClient | None":
-    """Build an OpenAI client when an API key is configured."""
+GROQ_BASE_URL = "https://api.groq.com/openai/v1"
+DEFAULT_GROQ_CHAT_MODEL = "llama-3.3-70b-versatile"
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or OpenAI is None:
+
+def build_openai_client() -> "OpenAIClient | None":
+    """Build a chat client — OpenAI if configured, otherwise Groq as fallback."""
+
+    if OpenAI is None:
         return None
-    return OpenAI(api_key=api_key)
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        return OpenAI(api_key=api_key)
+    groq_key = os.getenv("GROQ_API_KEY")
+    if groq_key:
+        return OpenAI(api_key=groq_key, base_url=GROQ_BASE_URL)
+    return None
+
+
+def get_chat_model() -> str:
+    """Return the chat model name appropriate for the configured provider."""
+
+    if os.getenv("OPENAI_API_KEY"):
+        return os.getenv("OPENAI_CHAT_MODEL", DEFAULT_ASSISTANT_MODEL)
+    if os.getenv("GROQ_API_KEY"):
+        return os.getenv("GROQ_CHAT_MODEL", DEFAULT_GROQ_CHAT_MODEL)
+    return DEFAULT_ASSISTANT_MODEL
 
 
 def parse_user_message(
@@ -59,18 +78,40 @@ def parse_user_message(
     if openai_client is None:
         return _parse_user_message_locally(cleaned_message)
 
-    response = openai_client.responses.parse(
-        model=os.getenv("OPENAI_ASSISTANT_MODEL", DEFAULT_ASSISTANT_MODEL),
-        instructions=SYSTEM_PROMPT,
-        input=cleaned_message,
-        text_format=AssistantAction,
+    import json
+
+    model = os.getenv("OPENAI_ASSISTANT_MODEL") or get_chat_model()
+    completion = openai_client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT + "\n\nRespond with a JSON object only."},
+            {"role": "user", "content": cleaned_message},
+        ],
+        response_format={"type": "json_object"},
         temperature=0,
-        max_output_tokens=400,
+        max_tokens=400,
     )
-    parsed_action = response.output_parsed
-    if parsed_action is None:
-        raise AssistantUnavailableError("OpenAI assistant returned no structured action.")
-    return parsed_action
+    raw = completion.choices[0].message.content or "{}"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return _parse_user_message_locally(cleaned_message)
+
+    try:
+        return AssistantAction.model_validate(data)
+    except Exception as exc:
+        # Groq sometimes returns invalid enum values — null out the offending fields and retry
+        from pydantic import ValidationError
+        if isinstance(exc, ValidationError):
+            for err in exc.errors():
+                field = err["loc"][0] if err["loc"] else None
+                if field and field != "action":
+                    data[field] = None
+            try:
+                return AssistantAction.model_validate(data)
+            except Exception:
+                pass
+        return _parse_user_message_locally(cleaned_message)
 
 
 def handle_message(message: str, *, context: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/src/ingestion/parsers/document_extractors.py
+++ b/src/ingestion/parsers/document_extractors.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 import tempfile
 
-from docling.document_converter import DocumentConverter
 from PIL import Image
 from pillow_heif import register_heif_opener
 
@@ -18,18 +17,17 @@ Image.MAX_IMAGE_PIXELS = None
 
 TEXT_SUFFIXES = {".txt", ".md"}
 IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp", ".heic", ".heif"}
+SPREADSHEET_SUFFIXES = {".xlsx", ".csv"}
 DOCLING_SUFFIXES = {
     ".pdf",
     ".docx",
     ".pptx",
     ".html",
-    ".csv",
-    ".xlsx",
     ".md",
     *IMAGE_SUFFIXES,
 }
 
-_CONVERTER: DocumentConverter | None = None
+_CONVERTER = None
 MAX_DOCLING_IMAGE_PIXELS = 12_000_000
 MAX_DOCLING_IMAGE_LONG_EDGE = 2400
 
@@ -50,10 +48,48 @@ def extract_document_text(
             source_type=SourceType.TEXT,
         )
 
+    if suffix in SPREADSHEET_SUFFIXES:
+        return _extract_spreadsheet(file_path)
+
     if suffix in DOCLING_SUFFIXES:
         return _extract_with_docling(file_path, include_structured_data=include_structured_data)
 
     raise ValueError(f"Unsupported program source: {file_path.suffix or '<no extension>'}")
+
+
+def _extract_spreadsheet(path: Path) -> ExtractedDocument:
+    import csv
+    import openpyxl
+
+    sections: list[str] = []
+
+    if path.suffix.lower() == ".csv":
+        with path.open(newline="", encoding="utf-8-sig") as fh:
+            rows = list(csv.reader(fh))
+        sections.append(_rows_to_markdown(path.stem, rows))
+    else:
+        wb = openpyxl.load_workbook(path, data_only=True)
+        for sheet_name in wb.sheetnames:
+            ws = wb[sheet_name]
+            rows = [[str(cell) if cell is not None else "" for cell in row] for row in ws.iter_rows(values_only=True)]
+            non_empty = [r for r in rows if any(v.strip() for v in r)]
+            if non_empty:
+                sections.append(_rows_to_markdown(sheet_name, non_empty))
+
+    text = "\n\n".join(sections) if sections else "(empty spreadsheet)"
+    return ExtractedDocument(
+        text=text,
+        source_type=SourceType.SPREADSHEET,
+        extraction_notes=["openpyxl_used"],
+        structured_markdown=text,
+    )
+
+
+def _rows_to_markdown(title: str, rows: list[list[str]]) -> str:
+    lines = [f"## {title}"]
+    for row in rows:
+        lines.append("| " + " | ".join(str(v).replace("|", "\\|").strip() for v in row) + " |")
+    return "\n".join(lines)
 
 
 def _extract_with_docling(path: Path, *, include_structured_data: bool) -> ExtractedDocument:
@@ -83,7 +119,9 @@ def _extract_with_docling(path: Path, *, include_structured_data: bool) -> Extra
     )
 
 
-def _get_converter() -> DocumentConverter:
+def _get_converter():
+    from docling.document_converter import DocumentConverter  # lazy import — not needed for /ios
+
     global _CONVERTER
     if _CONVERTER is None:
         _CONVERTER = DocumentConverter()


### PR DESCRIPTION
## Summary
- Groq fallback: coach now works with GROQ_API_KEY (free tier) when no OpenAI 
  key — uses chat.completions so it's provider-agnostic
- Native spreadsheet ingestion: .xlsx/.csv parse via openpyxl/csv directly 
  instead of Docling; lazy Docling import so module loads on iOS server
- Route dedup: removed duplicate /api/assistant/chat from web_demo.py


Commit | Contribution
--- | ---
ba4fbdf | Groq fallback + spreadsheet ingestion + route cleanup
1d3d427 | Workout history (Phase 1 & 2) + Supabase seed script
6350f5f | 25 integration tests (progression, post-workout summary, CSV export)
a5bfca1 | CSV export module + evidence library expanded to 11 sources
110ec9b | Progressive overload recommendations + smart post-workout summary
04b1db5 | Wire Excel write-back into log_set flow
1373da5 | Fix hardcoded date bug, cache Excel tracker
6fb7900 | Excel program tracker: read workouts + log sets
601642b | Exercise guidance layer + enriched coaching reply
2e39a7d | Audio cues in workout demo