### PR TITLE
Document local setup and implementation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ parallel without drifting on schemas.
 - `docs/team-plan.md`
 - `docs/api-contracts.md`
 - `docs/architecture.md`
+- `docs/implementation-history.md`
+- `ios/README.md` for the browser iOS prototype
+- `native-ios/README.md` for the Xcode/native iOS shell
 
 ## Recommended setup
 
@@ -38,16 +41,34 @@ conda activate team13
 pip install -r requirements.txt
 ```
 
-## Run the starter app
+## Run the local app
+
+The Flask demo server powers the desktop review flow, iOS browser prototype,
+coach chat routes, and native iOS shell during local development.
+
+For the browser/iOS prototype parser flow:
 
 ```bash
-python src/main.py
+python -m src.main --demo --host 127.0.0.1 --port 5001
 ```
+
+Then open `http://127.0.0.1:5001/ios/`.
+
+For the native Xcode shell on the iOS Simulator:
+
+```bash
+python -m src.main --demo --host 127.0.0.1 --port 5002
+```
+
+For a physical iPhone, run the server with `--host 0.0.0.0` and update the
+LAN IP in `native-ios/TrainAR/TrainAR/Info.plist` before launching from Xcode.
+See `native-ios/README.md` for the exact `TRAINAR_WEB_URL`, `ChatEndpointURL`,
+and `NSAppTransportSecurity` steps.
 
 ## Run tests
 
 ```bash
-pytest
+python -m pytest
 ```
 
 ## Environment variables
@@ -70,6 +91,17 @@ Do not commit `.env`.
 - `src/glasses/`: display demo, audio, controls
 - `src/app/`: summary, history, review flows
 - `src/export/`: external logging/export
+- `ios/`: browser-based iOS prototype
+- `native-ios/`: Xcode shell wrapping the web app and native bridges
 - `tests/fixtures/`: example payloads for team-wide testing
+
+## Documentation expectations
+
+- Keep feature behavior documented near the subsystem README.
+- Use PR descriptions and `docs/implementation-history.md` for historical
+  commit/PR context instead of creating retroactive issues for already-merged
+  work.
+- Use GitHub issues for active bugs, follow-ups, or remaining implementation
+  tasks.
 
 Charlie Abowd

--- a/docs/implementation-history.md
+++ b/docs/implementation-history.md
@@ -1,0 +1,70 @@
+# Implementation History
+
+This file gives future teammates a quick map from major implemented areas to
+the PRs and commits that introduced them. It is not a replacement for GitHub
+issues; use issues for open work and this document for historical context.
+
+## Foundation
+
+- `43fdb79` Scaffold shared contracts and team repo structure
+- `5e1c8ec` Add `__init__.py` to all subsystem packages
+
+These commits established the project layout around shared contracts:
+`src/contracts/`, `src/ingestion/`, `src/runtime/`, `src/sensing/`,
+`src/glasses/`, `src/app/`, and `src/export/`.
+
+## Program Ingestion
+
+- PR #34, `784b326` Add Docling and Gemini workout ingestion flow
+- PR #42, `16a9def` Improve block assignment and speed up Docling normalization
+
+These commits added the document import pipeline that converts uploaded program
+files into canonical `TrainingProgram` contracts.
+
+## Backend and Supabase App Data
+
+- PR #77, `21fd2f0` Add Supabase backend for iOS app
+- PR #77, `752d8c7` Fix Supabase migration review issues
+
+These commits added the Supabase-backed app data model for programs, days,
+blocks, exercises, sessions, sets, and personal records.
+
+## Assistant and Workout Control
+
+- PR #79, `1675cdb` Add OpenAI assistant service for workout commands
+- `25be9c4` Voice coach: add Supabase workout tools
+- PR #85, `b7bd9e4` Fix voice workout flows and HUD prep
+- PR #85, `1cd08e0` Add personalized evidence-backed coach onboarding
+
+These commits connected natural-language commands to structured workout
+actions, Supabase writes, off-current exercise confirmation, and personalized
+coach behavior.
+
+## Native iOS and Glasses
+
+- PR #33, `368a48c` Implement glasses display demo overlay
+- `2e39a7d` Add optional audio cues to workout demo
+- PR #80, `78bbd03` Add native iOS shell and glasses coach bridge
+- `601642b` Audio coach: exercise guidance layer + enriched next-set coaching reply
+
+These commits introduced the display demo, audio cues, native Xcode shell, and
+the bridge used by the iOS web app and glasses-related flows.
+
+## Summaries, Progression, and Export
+
+- PR #86, `110ec9b` Coach: progressive overload recommendations + smart post-workout summary
+- PR #86, `a5bfca1` Add CSV export module and expand evidence library to 11 sources
+- PR #86, `6350f5f` Tests: 25 integration tests for progression, post-workout summary, and CSV export
+
+These commits added progression recommendations, post-workout summaries, PR
+detection, CSV export endpoints, and integration coverage.
+
+## Local Development Notes
+
+- Browser iOS prototype: run `python -m src.main --demo --host 127.0.0.1 --port 5001`
+  and open `http://127.0.0.1:5001/ios/`.
+- Native iOS Simulator: run `python -m src.main --demo --host 127.0.0.1 --port 5002`.
+- Physical iPhone from Xcode: run `python -m src.main --demo --host 0.0.0.0 --port 5002`,
+  then update `TRAINAR_WEB_URL`, `ChatEndpointURL`, and
+  `NSAppTransportSecurity` in `native-ios/TrainAR/TrainAR/Info.plist` to use
+  your Mac's current LAN IP from `ipconfig getifaddr en0`.

--- a/docs/implementation-history.md
+++ b/docs/implementation-history.md
@@ -1,63 +1,83 @@
 # Implementation History
 
-This file gives future teammates a quick map from major implemented areas to
-the PRs and commits that introduced them. It is not a replacement for GitHub
-issues; use issues for open work and this document for historical context.
+This file gives future teammates a repo-wide map from major implemented areas to
+the PRs and commits that introduced them. It intentionally covers work from the
+whole team. It is not a replacement for GitHub issues; use issues for open work
+and this document for historical context.
 
-## Foundation
+## Foundation and Contracts
 
-- `43fdb79` Scaffold shared contracts and team repo structure
-- `5e1c8ec` Add `__init__.py` to all subsystem packages
-
-These commits established the project layout around shared contracts:
+The repo was first organized around shared contracts and subsystem boundaries:
 `src/contracts/`, `src/ingestion/`, `src/runtime/`, `src/sensing/`,
 `src/glasses/`, `src/app/`, and `src/export/`.
 
+Key references: `43fdb79`, `5e1c8ec`.
+
 ## Program Ingestion
 
-- PR #34, `784b326` Add Docling and Gemini workout ingestion flow
-- PR #42, `16a9def` Improve block assignment and speed up Docling normalization
+The ingestion path converts uploaded workout files into canonical
+`TrainingProgram` objects, preserving days, blocks, and exercises where the
+source document provides them.
 
-These commits added the document import pipeline that converts uploaded program
-files into canonical `TrainingProgram` contracts.
+Key references: PR #34 / `784b326`, PR #42 / `16a9def`.
 
-## Backend and Supabase App Data
+## Backend and App Data
 
-- PR #77, `21fd2f0` Add Supabase backend for iOS app
-- PR #77, `752d8c7` Fix Supabase migration review issues
+The app backend stores programs, days, blocks, exercises, sessions, sets, and
+personal records in Supabase. The browser iOS prototype reads and writes through
+that data model.
 
-These commits added the Supabase-backed app data model for programs, days,
-blocks, exercises, sessions, sets, and personal records.
+Key references: PR #77 / `21fd2f0`, `752d8c7`.
+
+## Frontend and Onboarding
+
+The frontend work reshaped signup, training profile setup, program screens, and
+coach-facing UI around the backend and assistant flows.
+
+Key references: PR #87 / `bd77ff5`.
 
 ## Assistant and Workout Control
 
-- PR #79, `1675cdb` Add OpenAI assistant service for workout commands
-- `25be9c4` Voice coach: add Supabase workout tools
-- PR #85, `b7bd9e4` Fix voice workout flows and HUD prep
-- PR #85, `1cd08e0` Add personalized evidence-backed coach onboarding
+The assistant work connects natural-language commands to structured actions:
+logging sets, starting or finishing workouts, querying PRs/history, generating
+workouts, confirming off-current exercise logging, and producing personalized
+coach replies.
 
-These commits connected natural-language commands to structured workout
-actions, Supabase writes, off-current exercise confirmation, and personalized
-coach behavior.
+Key references: PR #79 / `1675cdb`, `a1f8523`, `1ebc550`, `024854d`,
+`3f41435`, `6712786`, `25be9c4`, PR #85 / `b7bd9e4`, `1cd08e0`, PR #91 /
+`ba4fbdf`.
 
-## Native iOS and Glasses
+## Native iOS, Glasses, and HUD
 
-- PR #33, `368a48c` Implement glasses display demo overlay
-- `2e39a7d` Add optional audio cues to workout demo
-- PR #80, `78bbd03` Add native iOS shell and glasses coach bridge
-- `601642b` Audio coach: exercise guidance layer + enriched next-set coaching reply
+The glasses/native work includes the OpenCV display demo, optional audio cues,
+the Xcode shell, wake-word voice bridge, HUD prep, Ray-Ban/Meta DAT exploration,
+and demo-safe camera fallbacks.
 
-These commits introduced the display demo, audio cues, native Xcode shell, and
-the bridge used by the iOS web app and glasses-related flows.
+Key references: PR #33 / `368a48c`, `090b688`, `5184914`, `2e39a7d`, PR #80 /
+`78bbd03`, `062b004`, `31450da`, `601642b`, PR #90 / `5a404ba`, `9895779`.
+
+## Spreadsheet, History, and Seed Data
+
+Spreadsheet and history work added Jeff Nippard-style spreadsheet reading,
+write-back of logged weights, day-number handling, richer workout history, and
+Supabase seed tooling for demos.
+
+Key references: `6fb7900`, `1373da5`, `04b1db5`, `1d3d427`.
 
 ## Summaries, Progression, and Export
 
-- PR #86, `110ec9b` Coach: progressive overload recommendations + smart post-workout summary
-- PR #86, `a5bfca1` Add CSV export module and expand evidence library to 11 sources
-- PR #86, `6350f5f` Tests: 25 integration tests for progression, post-workout summary, and CSV export
+Training intelligence work added progression recommendations, estimated 1RMs,
+post-workout summaries, PR detection, CSV exports, evidence-library expansion,
+and integration coverage.
 
-These commits added progression recommendations, post-workout summaries, PR
-detection, CSV export endpoints, and integration coverage.
+Key references: PR #86 / `110ec9b`, `a5bfca1`, `6350f5f`.
+
+## Repository Hygiene and Demo Safety
+
+Cleanup work removed local artifacts and oversized files, tightened demo login
+safety, and kept shareable branches from carrying local-only bypasses.
+
+Key references: `c181461`, `3a987ec`, `1f02ec7`, `91024a3`.
 
 ## Local Development Notes
 

--- a/native-ios/README.md
+++ b/native-ios/README.md
@@ -22,20 +22,56 @@ Meta glasses -> Meta AI permissions/session -> native iOS shell -> TrainAR web U
 1. Open `native-ios/TrainAR/TrainAR.xcodeproj` in Xcode.
 2. Select the `TrainAR` target.
 3. In **Signing & Capabilities**, select your team.
-4. Start the Python demo server from the repo root:
+4. Start the Python demo server from the repo root.
+
+   For the iOS Simulator:
 
    ```bash
    python -m src.main --demo --host 127.0.0.1 --port 5002
    ```
 
-5. Run the app in the iOS Simulator.
+   For a physical iPhone on the same Wi-Fi as your Mac, bind Flask to all
+   interfaces so the phone can reach it:
 
-The default web URL is `http://127.0.0.1:5002/ios/`, which works in the
-Simulator. On a physical iPhone, `127.0.0.1` points at the phone itself, so set
-`TRAINAR_WEB_URL` in `TrainAR/Info.plist` to either:
+   ```bash
+   python -m src.main --demo --host 0.0.0.0 --port 5002
+   ```
 
-- a LAN URL for your Mac, for example `http://192.168.1.20:5002/ios/`
-- a deployed HTTPS URL, for example Vercel
+5. Configure `TrainAR/Info.plist` before running on a physical iPhone.
+
+   The default web URL, `http://127.0.0.1:5002/ios/`, only works in the
+   Simulator. On a physical iPhone, `127.0.0.1` points at the phone itself.
+   Find your Mac's current LAN IP:
+
+   ```bash
+   ipconfig getifaddr en0
+   ```
+
+   Update both local endpoints to use that IP:
+
+   ```xml
+   <key>TRAINAR_WEB_URL</key>
+   <string>http://YOUR_MAC_IP:5002/ios/</string>
+   <key>ChatEndpointURL</key>
+   <string>http://YOUR_MAC_IP:5002/api/chat</string>
+   ```
+
+   Also add `YOUR_MAC_IP` under `NSAppTransportSecurity` ->
+   `NSExceptionDomains`, matching the existing localhost/IP entries, so iOS
+   allows local HTTP during development.
+
+6. Run the app from Xcode.
+
+   If the phone cannot connect, confirm:
+
+   - the Mac and iPhone are on the same network
+   - the server is running with `--host 0.0.0.0`
+   - `TRAINAR_WEB_URL` and `ChatEndpointURL` use the same current Mac IP
+   - the IP is present in `NSExceptionDomains`
+   - iOS local-network permission was accepted
+
+   On networks that isolate devices, use an HTTPS tunnel such as ngrok and set
+   `TRAINAR_WEB_URL` / `ChatEndpointURL` to the tunnel URL instead.
 
 ## Bridge contract
 


### PR DESCRIPTION
## Summary
- Clarify root README setup for browser iOS, native iOS, and test commands.
- Expand native iOS README with physical-device LAN IP, `TRAINAR_WEB_URL`, `ChatEndpointURL`, and ATS setup.
- Add an implementation history doc tying major repo areas to PRs and commits.

## Test plan
- Documentation-only change; no tests run.


Made with [Cursor](https://cursor.com)